### PR TITLE
Enforce all types created through constructors

### DIFF
--- a/src/api/schema/examples/blog.ts
+++ b/src/api/schema/examples/blog.ts
@@ -28,18 +28,21 @@
  *
  */
 import {
+  association,
   belongsToType,
   booleanDataType,
   dateTimeDataType,
+  field,
   hasManyType,
   manyToManyModelType,
+  model,
   Model,
+  schema,
   Schema,
   stringDataType,
   textDataType,
 } from '@src/core/schema'
 import { fromParts } from '@src/utils/dateTime'
-import { uniqueId } from '@src/utils/string'
 import { BLOG_ID } from './ids'
 
 const time = fromParts(2021, 4, 1)
@@ -55,539 +58,370 @@ enum Id {
   User = '6XfrfnVeY7KTKukt26dQZ',
 }
 
-const category: Model = {
+const category: Model = model({
   id: Id.Category,
   name: 'category',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'title',
       type: stringDataType({ length: 75 }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'meta title',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'slug',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
       required: true,
       unique: true,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
+    association({
       alias: 'parent',
       sourceModelId: Id.Category,
       targetModelId: Id.Category,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'children',
       sourceModelId: Id.Category,
       targetModelId: Id.Category,
       type: hasManyType(),
       foreignKey: 'parent id',
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.Category,
       targetModelId: Id.PostCategory,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.Category,
       targetModelId: Id.Post,
       type: manyToManyModelType(Id.PostCategory),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const post: Model = {
+const post: Model = model({
   id: Id.Post,
   name: 'post',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'title',
       type: stringDataType({ length: 75 }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'meta title',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'slug',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
       required: true,
       unique: true,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'summary',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'published',
       type: booleanDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'published at',
       type: dateTimeDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
+    association({
       alias: 'author',
       sourceModelId: Id.Post,
       targetModelId: Id.User,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'parent',
       sourceModelId: Id.Post,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'children',
       sourceModelId: Id.Post,
       targetModelId: Id.Post,
       type: hasManyType(),
       foreignKey: 'parent id',
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.Post,
       targetModelId: Id.PostCategory,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.Post,
       targetModelId: Id.Category,
       type: manyToManyModelType(Id.PostCategory),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'comments',
       sourceModelId: Id.Post,
       targetModelId: Id.PostComment,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'meta',
       sourceModelId: Id.Post,
       targetModelId: Id.PostMeta,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.Post,
       targetModelId: Id.PostTag,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.Post,
       targetModelId: Id.Tag,
       type: manyToManyModelType(Id.PostTag),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const postCategory: Model = {
+const postCategory: Model = model({
   id: Id.PostCategory,
   name: 'post category',
   createdAt: time,
   updatedAt: time,
   fields: [],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       sourceModelId: Id.PostCategory,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.PostCategory,
       targetModelId: Id.Category,
       type: belongsToType(),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const postComment: Model = {
+const postComment: Model = model({
   id: Id.PostComment,
   name: 'post comment',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'title',
       type: stringDataType({ length: 75 }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'published',
       type: booleanDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'published at',
       type: dateTimeDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       sourceModelId: Id.PostComment,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'parent',
       sourceModelId: Id.PostComment,
       targetModelId: Id.PostComment,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'children',
       sourceModelId: Id.PostComment,
       targetModelId: Id.PostComment,
       type: hasManyType(),
       foreignKey: 'parent id',
-    },
+    }),
   ],
-}
+})
 
-const postMeta: Model = {
+const postMeta: Model = model({
   id: Id.PostMeta,
   name: 'post meta',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'key',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
       required: true,
       unique: true,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       sourceModelId: Id.PostMeta,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const postTag: Model = {
+const postTag: Model = model({
   id: Id.PostTag,
   name: 'post tag',
   createdAt: time,
   updatedAt: time,
   fields: [],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       sourceModelId: Id.PostTag,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.PostTag,
       targetModelId: Id.Tag,
       type: belongsToType(),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const tag: Model = {
+const tag: Model = model({
   id: Id.Tag,
   name: 'tag',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'title',
       type: stringDataType({ length: 75 }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'meta title',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'slug',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
       required: true,
       unique: true,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       sourceModelId: Id.Tag,
       targetModelId: Id.PostTag,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.Tag,
       targetModelId: Id.Post,
       type: manyToManyModelType(Id.PostTag),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const user: Model = {
+const user: Model = model({
   id: Id.User,
   name: 'user',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'first name',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'middle name',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'last name',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'mobile',
       type: stringDataType({ length: 15 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'email',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'password hash',
       type: stringDataType({ length: 32 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'registered at',
       type: dateTimeDataType({ defaultNow: true }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'last login',
       type: dateTimeDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'intro',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'profile',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       sourceModelId: Id.User,
       targetModelId: Id.Post,
       type: hasManyType(),
       foreignKey: 'author id',
-    },
+    }),
   ],
-}
+})
 
-const blogSchema: Schema = {
+const blogSchema: Schema = schema({
   id: BLOG_ID,
   name: 'blog',
   createdAt: time,
   updatedAt: time,
-  forkedFrom: null,
   models: [category, post, postCategory, postComment, postMeta, postTag, tag, user],
-}
+})
 
 export default blogSchema

--- a/src/api/schema/examples/employees.ts
+++ b/src/api/schema/examples/employees.ts
@@ -20,18 +20,21 @@
  *
  */
 import {
+  association,
   belongsToType,
   dateDataType,
   enumDataType,
+  field,
   hasManyType,
   integerDataType,
   manyToManyModelType,
+  model,
   Model,
+  schema,
   Schema,
   stringDataType,
 } from '@src/core/schema'
 import { fromParts } from '@src/utils/dateTime'
-import { uniqueId } from '@src/utils/string'
 import { EMPLOYEES_ID } from './ids'
 
 const time = fromParts(2020, 10, 1)
@@ -45,383 +48,295 @@ enum Id {
   Salaries = 'Xq55KHZ19UT9ob31iT_D_',
 }
 
-const employee: Model = {
+const employee: Model = model({
   id: Id.Employees,
   name: 'employees',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'emp_no',
       type: integerDataType({ autoincrement: true }),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'birth_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'first_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'last_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'gender',
       type: enumDataType({ values: ['M', 'F', 'O'] }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'hire_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       foreignKey: 'emp_no',
       type: hasManyType(),
       sourceModelId: Id.Employees,
       targetModelId: Id.Salaries,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       foreignKey: 'emp_no',
       type: hasManyType(),
       sourceModelId: Id.Employees,
       targetModelId: Id.Titles,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'employingDepartment',
       foreignKey: 'emp_no',
       sourceModelId: Id.Employees,
       targetModelId: Id.Departments,
       type: manyToManyModelType(Id.DepartmentEmployees, 'dept_no'),
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'managedDepartment',
       foreignKey: 'emp_no',
       sourceModelId: Id.Employees,
       targetModelId: Id.Departments,
       type: manyToManyModelType(Id.DepartmentManagers, 'dept_no'),
-    },
+    }),
   ],
-}
+})
 
-const department: Model = {
+const department: Model = model({
   id: Id.Departments,
   name: 'departments',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'dept_no',
       type: stringDataType(),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'dept_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
+    association({
       alias: 'employee',
       foreignKey: 'emp_no',
       sourceModelId: Id.Departments,
       targetModelId: Id.Employees,
       type: manyToManyModelType(Id.DepartmentEmployees, 'dept_no'),
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'manager',
       foreignKey: 'emp_no',
       sourceModelId: Id.Departments,
       targetModelId: Id.Employees,
       type: manyToManyModelType(Id.DepartmentManagers, 'dept_no'),
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       foreignKey: 'dept_no',
       type: hasManyType(),
       sourceModelId: Id.Departments,
       targetModelId: Id.DepartmentEmployees,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       foreignKey: 'dept_no',
       type: hasManyType(),
       sourceModelId: Id.Departments,
       targetModelId: Id.DepartmentManagers,
-    },
+    }),
   ],
-}
+})
 
-const departmentEmployee: Model = {
+const departmentEmployee: Model = model({
   id: Id.DepartmentEmployees,
   name: 'dept_emp',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'emp_no',
       type: integerDataType(),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'dept_no',
       type: stringDataType(),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'from_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'to_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       foreignKey: 'emp_no',
       type: belongsToType(),
       sourceModelId: Id.DepartmentEmployees,
       targetModelId: Id.Employees,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       foreignKey: 'dept_no',
       type: belongsToType(),
       sourceModelId: Id.DepartmentEmployees,
       targetModelId: Id.Departments,
-    },
+    }),
   ],
-}
+})
 
-const departmentManager: Model = {
+const departmentManager: Model = model({
   id: Id.DepartmentManagers,
   name: 'dept_manager',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'emp_no',
       type: integerDataType(),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'dept_no',
       type: stringDataType(),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'from_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'to_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       foreignKey: 'emp_no',
       type: belongsToType(),
       sourceModelId: Id.DepartmentManagers,
       targetModelId: Id.Employees,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       foreignKey: 'dept_no',
       type: belongsToType(),
       sourceModelId: Id.DepartmentManagers,
       targetModelId: Id.Departments,
-    },
+    }),
   ],
-}
+})
 
-const title: Model = {
+const title: Model = model({
   id: Id.Titles,
   name: 'titles',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'emp_no',
       type: integerDataType({ autoincrement: false }),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'title',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'from_date',
       type: dateDataType(),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'to_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       foreignKey: 'emp_no',
       type: belongsToType(),
       sourceModelId: Id.Titles,
       targetModelId: Id.Employees,
-    },
+    }),
   ],
-}
+})
 
-const salary: Model = {
+const salary: Model = model({
   id: Id.Salaries,
   name: 'salaries',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'emp_no',
       type: integerDataType({ autoincrement: false }),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'salary',
       type: integerDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'from_date',
       type: dateDataType(),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'to_date',
       type: dateDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       foreignKey: 'emp_no',
       type: belongsToType(),
       sourceModelId: Id.Salaries,
       targetModelId: Id.Employees,
-    },
+    }),
   ],
-}
+})
 
-const employeeSchema: Schema = {
+const employeeSchema: Schema = schema({
   id: EMPLOYEES_ID,
   name: 'employee dataset',
   createdAt: time,
   updatedAt: time,
-  forkedFrom: null,
   models: [employee, department, departmentEmployee, departmentManager, title, salary],
-}
+})
 
 export default employeeSchema

--- a/src/api/schema/examples/sakila.ts
+++ b/src/api/schema/examples/sakila.ts
@@ -21,6 +21,7 @@
 
 import {
   arrayDataType,
+  association,
   belongsToType,
   blobDataType,
   booleanDataType,
@@ -28,16 +29,18 @@ import {
   dateTimeDataType,
   decimalDataType,
   enumDataType,
+  field,
   hasManyType,
   hasOneType,
   integerDataType,
   manyToManyModelType,
+  model,
   Model,
+  schema,
   Schema,
   stringDataType,
 } from '@src/core/schema'
 import { fromParts } from '@src/utils/dateTime'
-import { uniqueId } from '@src/utils/string'
 import { SAKILA_ID } from './ids'
 
 const time = fromParts(2020, 1, 1)
@@ -60,802 +63,570 @@ enum Id {
   Store = 'SKfg8yJLz5XTlCWRuQgMo',
 }
 
-const actor: Model = {
+const actor: Model = model({
   id: Id.Actor,
   name: 'actor',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'first_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'last_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       foreignKey: 'actor_id',
       sourceModelId: Id.Actor,
       targetModelId: Id.Film,
       type: manyToManyModelType(Id.FilmActor, 'film_id'),
-    },
+    }),
   ],
-}
+})
 
-const film: Model = {
+const film: Model = model({
   id: Id.Film,
   name: 'film',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'title',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'description',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'release_year',
       type: integerDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'language_id',
       type: integerDataType({ unsigned: true }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'original_language_id',
       type: integerDataType({ unsigned: true }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'rental_duration',
       type: integerDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'rental_rate',
       type: decimalDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'length',
       type: integerDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'rating',
       type: enumDataType({ values: ['G', 'PG', 'PG-13', 'R', 'NC-17'] }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'special_feature',
       type: arrayDataType({
         arrayType: enumDataType({
           values: ['Trailers', 'Commentaries', 'Deleted Scenes', 'Behind the Scenes'],
         }),
       }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({
       type: belongsToType(),
       sourceModelId: Id.Film,
       targetModelId: Id.Language,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'original_language',
       foreignKey: 'original_language_id',
       type: belongsToType(),
       sourceModelId: Id.Film,
       targetModelId: Id.Language,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       foreignKey: 'film_id',
       type: hasManyType(),
       sourceModelId: Id.Film,
       targetModelId: Id.Inventory,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       foreignKey: 'film_id',
       sourceModelId: Id.Film,
       targetModelId: Id.Actor,
       type: manyToManyModelType(Id.FilmActor, 'actor_id'),
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       foreignKey: 'film_id',
       sourceModelId: Id.Film,
       targetModelId: Id.Category,
       type: manyToManyModelType(Id.FilmCategory, 'category_id'),
-    },
+    }),
   ],
-}
+})
 
-const language: Model = {
+const language: Model = model({
   id: Id.Language,
   name: 'language',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({
       type: hasManyType(),
       sourceModelId: Id.Language,
       targetModelId: Id.Film,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'original_language_film',
       foreignKey: 'original_language_id',
       type: hasManyType(),
       sourceModelId: Id.Language,
       targetModelId: Id.Film,
-    },
+    }),
   ],
-}
+})
 
-const category: Model = {
+const category: Model = model({
   id: Id.Category,
   name: 'category',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       foreignKey: 'category_id',
       sourceModelId: Id.Category,
       targetModelId: Id.Film,
       type: manyToManyModelType(Id.FilmCategory, 'film_id'),
-    },
+    }),
   ],
-}
+})
 
-const inventory: Model = {
+const inventory: Model = model({
   id: Id.Inventory,
   name: 'inventory',
   createdAt: time,
   updatedAt: time,
   fields: [],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({
       type: belongsToType(),
       sourceModelId: Id.Inventory,
       targetModelId: Id.Film,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: belongsToType(),
       sourceModelId: Id.Inventory,
       targetModelId: Id.Store,
-    },
+    }),
   ],
-}
+})
 
-const store: Model = {
+const store: Model = model({
   id: Id.Store,
   name: 'store',
   createdAt: time,
   updatedAt: time,
   fields: [],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({
       type: hasManyType(),
       sourceModelId: Id.Store,
       targetModelId: Id.Inventory,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: hasManyType(),
       sourceModelId: Id.Store,
       targetModelId: Id.Staff,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: hasManyType(),
       sourceModelId: Id.Store,
       targetModelId: Id.Customer,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'manager',
       foreignKey: 'manager_staff_id',
       type: belongsToType(),
       sourceModelId: Id.Store,
       targetModelId: Id.Staff,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: belongsToType(),
       sourceModelId: Id.Store,
       targetModelId: Id.Address,
-    },
+    }),
   ],
-}
+})
 
-const staff: Model = {
+const staff: Model = model({
   id: Id.Staff,
   name: 'staff',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'first_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'last_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'picture',
       type: blobDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'email',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'active',
       type: booleanDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'username',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'password',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({
       type: belongsToType(),
       targetModelId: Id.Store,
       sourceModelId: Id.Staff,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'managed_store',
       foreignKey: 'manager_staff_id',
       type: hasManyType(),
       targetModelId: Id.Store,
       sourceModelId: Id.Staff,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: belongsToType(),
       targetModelId: Id.Address,
       sourceModelId: Id.Staff,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: hasManyType(),
       targetModelId: Id.Rental,
       sourceModelId: Id.Staff,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: hasManyType(),
       targetModelId: Id.Payment,
       sourceModelId: Id.Staff,
-    },
+    }),
   ],
-}
+})
 
-const customer: Model = {
+const customer: Model = model({
   id: Id.Customer,
   name: 'customer',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'first_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'last_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'email',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'active',
       type: booleanDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({
       type: belongsToType(),
       targetModelId: Id.Store,
       sourceModelId: Id.Customer,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: belongsToType(),
       targetModelId: Id.Address,
       sourceModelId: Id.Customer,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: hasManyType(),
       targetModelId: Id.Rental,
       sourceModelId: Id.Customer,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: hasManyType(),
       targetModelId: Id.Payment,
       sourceModelId: Id.Customer,
-    },
+    }),
   ],
-}
+})
 
-const address: Model = {
+const address: Model = model({
   id: Id.Address,
   name: 'address',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'address',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'address2',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'postal_code',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'phone',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({
       type: belongsToType(),
       targetModelId: Id.City,
       sourceModelId: Id.Address,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: hasOneType(),
       targetModelId: Id.Customer,
       sourceModelId: Id.Address,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: hasOneType(),
       targetModelId: Id.Staff,
       sourceModelId: Id.Address,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: hasOneType(),
       targetModelId: Id.Store,
       sourceModelId: Id.Address,
-    },
+    }),
   ],
-}
+})
 
-const rental: Model = {
+const rental: Model = model({
   id: Id.Rental,
   name: 'rental',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'rental_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'return_date',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({
       type: belongsToType(),
       targetModelId: Id.Inventory,
       sourceModelId: Id.Rental,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: belongsToType(),
       targetModelId: Id.Customer,
       sourceModelId: Id.Rental,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: belongsToType(),
       targetModelId: Id.Staff,
       sourceModelId: Id.Rental,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: hasManyType(),
       targetModelId: Id.Payment,
       sourceModelId: Id.Rental,
-    },
+    }),
   ],
-}
+})
 
-const payment: Model = {
+const payment: Model = model({
   id: Id.Payment,
   name: 'payment',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'amount',
       type: decimalDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'payment_date',
       type: dateTimeDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({
       type: belongsToType(),
       targetModelId: Id.Customer,
       sourceModelId: Id.Payment,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: belongsToType(),
       targetModelId: Id.Staff,
       sourceModelId: Id.Payment,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: belongsToType(),
       targetModelId: Id.Rental,
       sourceModelId: Id.Payment,
-    },
+    }),
   ],
-}
+})
 
-const city: Model = {
+const city: Model = model({
   id: Id.City,
   name: 'city',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'city',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({
       type: belongsToType(),
       targetModelId: Id.Country,
       sourceModelId: Id.City,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: hasManyType(),
       targetModelId: Id.Address,
       sourceModelId: Id.City,
-    },
+    }),
   ],
-}
+})
 
-const country: Model = {
+const country: Model = model({
   id: Id.Country,
   name: 'country',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'country',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({
       type: hasManyType(),
       targetModelId: Id.City,
       sourceModelId: Id.Country,
-    },
+    }),
   ],
-}
+})
 
-const film_actor: Model = {
+const film_actor: Model = model({
   id: Id.FilmActor,
   name: 'film_actor',
   createdAt: time,
   updatedAt: time,
   fields: [],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({
       type: belongsToType(),
       sourceModelId: Id.FilmActor,
       targetModelId: Id.Film,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: belongsToType(),
       sourceModelId: Id.FilmActor,
       targetModelId: Id.Actor,
-    },
+    }),
   ],
-}
+})
 
-const film_category: Model = {
+const film_category: Model = model({
   id: Id.FilmCategory,
   name: 'film_category',
   createdAt: time,
   updatedAt: time,
   fields: [],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({
       type: belongsToType(),
       sourceModelId: Id.FilmCategory,
       targetModelId: Id.Film,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       type: belongsToType(),
       sourceModelId: Id.FilmCategory,
       targetModelId: Id.Category,
-    },
+    }),
   ],
-}
+})
 
 // https://dev.mysql.com/doc/sakila/en/
-const sakilaSchema: Schema = {
+const sakilaSchema: Schema = schema({
   id: SAKILA_ID,
   name: 'sakila',
   createdAt: time,
   updatedAt: time,
-  forkedFrom: null,
   models: [
     actor,
     film,
@@ -873,6 +644,6 @@ const sakilaSchema: Schema = {
     film_actor,
     film_category,
   ],
-}
+})
 
 export default sakilaSchema

--- a/src/api/schema/implementations/localStorage/__fixtures__/blogTranslatedFromLegacy.ts
+++ b/src/api/schema/implementations/localStorage/__fixtures__/blogTranslatedFromLegacy.ts
@@ -1,203 +1,159 @@
 import {
-  AssociationTypeType,
+  association,
+  belongsToType,
   DataTypeType,
+  field,
+  hasManyType,
+  manyToManyTableType,
+  model,
+  schema,
   Schema,
   stringDataType,
-  ThroughType,
 } from '@src/core/schema'
-import { now } from '@src/utils/dateTime'
-import { uniqueId } from '@src/utils/string'
 
-export const blogTranslatedFromLegacy: Schema = {
-  id: uniqueId(),
+export const blogTranslatedFromLegacy: Schema = schema({
   name: 'Blog',
-  createdAt: now(),
-  updatedAt: now(),
-  forkedFrom: null,
   models: [
-    {
+    model({
       id: 'e656d286-e249-4844-ab0a-f4bb6ae8c44f',
       name: 'Post',
       fields: [
-        {
+        field({
           id: 'a6379f06-4ea5-4462-9b89-54ad60a2bc96',
           name: 'Title',
           type: stringDataType(),
-          primaryKey: false,
           required: true,
-          unique: false,
-        },
-        {
+        }),
+        field({
           id: '4c299161-38de-48b2-bab8-ccf451188344',
           name: 'Content',
           type: { type: DataTypeType.Text },
-          primaryKey: false,
-          required: false,
-          unique: false,
-        },
+        }),
       ],
       associations: [
-        {
+        association({
           id: '265bd2a1-04ba-4ca3-9e21-60a23b77ea38',
-          type: { type: AssociationTypeType.BelongsTo },
+          type: belongsToType(),
           sourceModelId: 'e656d286-e249-4844-ab0a-f4bb6ae8c44f',
           targetModelId: '55dded8d-6b6a-401f-a799-d10ce03296e9',
           alias: 'Author',
-          foreignKey: null,
-        },
-        {
+        }),
+        association({
           id: '7bd0f700-bf8d-4fa6-bab2-338c0d6f3969',
-          type: { type: AssociationTypeType.HasMany },
+          type: hasManyType(),
           sourceModelId: 'e656d286-e249-4844-ab0a-f4bb6ae8c44f',
           targetModelId: 'f38d213b-3317-402a-9702-7d37c1cc03cb',
-          alias: null,
-          foreignKey: null,
-        },
-        {
+        }),
+        association({
           id: '6b8ee99f-eac3-48bc-90e9-db5da71de988',
-          type: {
-            type: AssociationTypeType.ManyToMany,
-            through: { type: ThroughType.ThroughTable, table: 'Post Tags' },
-            targetFk: null,
-          },
+          type: manyToManyTableType('Post Tags'),
           sourceModelId: 'e656d286-e249-4844-ab0a-f4bb6ae8c44f',
           targetModelId: '8c934d50-a8aa-4ea5-bf99-e3f5de6d6af5',
-          alias: null,
-          foreignKey: null,
-        },
+        }),
       ],
-      createdAt: now(),
-      updatedAt: now(),
-    },
-    {
+    }),
+    model({
       id: '55dded8d-6b6a-401f-a799-d10ce03296e9',
       name: 'User',
       fields: [
-        {
+        field({
           id: '41edff74-ace8-4f17-a297-c3bce0968f44',
           name: 'First Name',
           type: stringDataType(),
-          primaryKey: false,
           required: true,
-          unique: false,
-        },
-        {
+        }),
+        field({
           id: '12e09a2e-d370-48bf-ab8a-0072708170b7',
           name: 'Last Name',
           type: stringDataType(),
-          primaryKey: false,
           required: true,
-          unique: false,
-        },
-        {
+        }),
+        field({
           id: '0ddb0f8e-0a2f-413e-b2f2-d6bb5bdc8a84',
           name: 'Email',
           type: stringDataType(),
-          primaryKey: false,
           required: true,
           unique: true,
-        },
+        }),
       ],
       associations: [
-        {
+        association({
           id: '6ab58e40-b888-4b3a-8f24-3e26ccefeeab',
-          type: { type: AssociationTypeType.HasMany },
+          type: hasManyType(),
           sourceModelId: '55dded8d-6b6a-401f-a799-d10ce03296e9',
           targetModelId: 'e656d286-e249-4844-ab0a-f4bb6ae8c44f',
-          alias: null,
           foreignKey: 'author id',
-        },
-        {
+        }),
+        association({
           id: '7241057f-cbd8-45bc-a766-857dded9ec48',
-          type: { type: AssociationTypeType.HasMany },
+          type: hasManyType(),
           sourceModelId: '55dded8d-6b6a-401f-a799-d10ce03296e9',
           targetModelId: 'f38d213b-3317-402a-9702-7d37c1cc03cb',
-          alias: null,
           foreignKey: 'author id',
-        },
+        }),
       ],
-      createdAt: now(),
-      updatedAt: now(),
-    },
-    {
+    }),
+    model({
       id: '8c934d50-a8aa-4ea5-bf99-e3f5de6d6af5',
       name: 'Tag',
       fields: [
-        {
+        field({
           id: '16e49434-2904-46b6-bc6c-68860c15a856',
           name: 'Name',
           type: stringDataType(),
-          primaryKey: false,
           required: true,
-          unique: false,
-        },
+        }),
       ],
       associations: [
-        {
+        association({
           id: '7169d0cb-1982-45df-a243-71fc539b7e7e',
-          type: {
-            type: AssociationTypeType.ManyToMany,
-            through: { type: ThroughType.ThroughTable, table: 'Post Tags' },
-            targetFk: null,
-          },
+          type: manyToManyTableType('Post Tags'),
           sourceModelId: '8c934d50-a8aa-4ea5-bf99-e3f5de6d6af5',
           targetModelId: 'e656d286-e249-4844-ab0a-f4bb6ae8c44f',
-          alias: null,
-          foreignKey: null,
-        },
+        }),
       ],
-      createdAt: now(),
-      updatedAt: now(),
-    },
-    {
+    }),
+    model({
       id: 'f38d213b-3317-402a-9702-7d37c1cc03cb',
       name: 'Comment',
       fields: [
-        {
+        field({
           id: '60ee41cc-7d56-4835-8ea4-70274fab7c4d',
           name: 'Content',
           type: { type: DataTypeType.Text },
-          primaryKey: false,
           required: true,
-          unique: false,
-        },
+        }),
       ],
       associations: [
-        {
+        association({
           id: '76acd309-c7d6-42bb-a390-9479b4edf688',
-          type: { type: AssociationTypeType.BelongsTo },
+          type: belongsToType(),
           sourceModelId: 'f38d213b-3317-402a-9702-7d37c1cc03cb',
           targetModelId: '55dded8d-6b6a-401f-a799-d10ce03296e9',
           alias: 'Author',
-          foreignKey: null,
-        },
-        {
+        }),
+        association({
           id: '36a00526-bc28-4553-b0db-b12428bf70bf',
-          type: { type: AssociationTypeType.BelongsTo },
+          type: belongsToType(),
           sourceModelId: 'f38d213b-3317-402a-9702-7d37c1cc03cb',
           targetModelId: 'e656d286-e249-4844-ab0a-f4bb6ae8c44f',
-          alias: null,
-          foreignKey: null,
-        },
-        {
+        }),
+        association({
           id: '209d5e91-7d2b-4d71-9756-3934e7349d02',
-          type: { type: AssociationTypeType.BelongsTo },
+          type: belongsToType(),
           sourceModelId: 'f38d213b-3317-402a-9702-7d37c1cc03cb',
           targetModelId: 'f38d213b-3317-402a-9702-7d37c1cc03cb',
           alias: 'Parent',
-          foreignKey: null,
-        },
-        {
+        }),
+        association({
           id: '61f32047-c929-4472-a6ea-2c8e5f1085b9',
-          type: { type: AssociationTypeType.HasMany },
+          type: hasManyType(),
           sourceModelId: 'f38d213b-3317-402a-9702-7d37c1cc03cb',
           targetModelId: 'f38d213b-3317-402a-9702-7d37c1cc03cb',
           alias: 'Response',
           foreignKey: 'parent id',
-        },
+        }),
       ],
-      createdAt: now(),
-      updatedAt: now(),
-    },
+    }),
   ],
-}
+})

--- a/src/api/schema/implementations/localStorage/__fixtures__/blogTranslatedFromV1.ts
+++ b/src/api/schema/implementations/localStorage/__fixtures__/blogTranslatedFromV1.ts
@@ -28,14 +28,18 @@
  *
  */
 import {
+  Model,
+  Schema,
+  association,
   belongsToType,
   bigIntDataType,
   booleanDataType,
   dateTimeDataType,
+  field,
   hasManyType,
   manyToManyModelType,
-  Model,
-  Schema,
+  model,
+  schema,
   stringDataType,
   textDataType,
 } from '@src/core/schema'
@@ -54,620 +58,482 @@ const Id = {
   User: 'ivaiETEdGs',
 } as const
 
-const category: Model = {
+const category: Model = model({
   id: Id.Category,
   name: 'category',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
+    field({
       id: 'T4qQXIU57t',
       name: 'id',
       type: bigIntDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'wLaKerwKHR',
       name: 'title',
       type: stringDataType({ length: 75 }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'B1XfKBFlVl',
       name: 'meta title',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'BCinV1ySl1',
       name: 'slug',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
       required: true,
       unique: true,
-    },
-    {
+    }),
+    field({
       id: 'F8N_KcjAqE',
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
+    association({
       id: 'oDibzTR5C',
       alias: 'parent',
       sourceModelId: Id.Category,
       targetModelId: Id.Category,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: '7lc6O2PM91',
       alias: 'children',
       sourceModelId: Id.Category,
       targetModelId: Id.Category,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: 'wcfc-hVPMo',
-      alias: null,
       sourceModelId: Id.Category,
       targetModelId: Id.PostCategory,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: 'hN7l0LA6k5l',
-      alias: null,
       sourceModelId: Id.Category,
       targetModelId: Id.Post,
       type: manyToManyModelType(Id.PostCategory),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const post: Model = {
+const post: Model = model({
   id: Id.Post,
   name: 'post',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
+    field({
       id: 'JF3PYgKWdxc',
       name: 'id',
       type: bigIntDataType(),
       primaryKey: true,
-
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'uS6fbupku5b',
       name: 'title',
       type: stringDataType({ length: 75 }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: '8tK7CCDZt2R',
       name: 'meta title',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'ljY-X8RoAL_',
       name: 'slug',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
       required: true,
       unique: true,
-    },
-    {
+    }),
+    field({
       id: '6rlsTFVLWD8',
       name: 'summary',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'vDhgus3e1M8',
       name: 'published',
       type: booleanDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'WWVBERtnLH5',
       name: 'published at',
       type: dateTimeDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'JZX74kV3RJB',
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
+    association({
       id: '_XbLHymzQ54',
       alias: 'author',
       sourceModelId: Id.Post,
       targetModelId: Id.User,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: 'XHnda0nh3I8',
       alias: 'parent',
       sourceModelId: Id.Post,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: 'uokEC1_-88B',
       alias: 'children',
       sourceModelId: Id.Post,
       targetModelId: Id.Post,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: 'nZBcsVQMiVe',
-      alias: null,
       sourceModelId: Id.Post,
       targetModelId: Id.PostCategory,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: 'GTvEzMsP-CY',
-      alias: null,
       sourceModelId: Id.Post,
       targetModelId: Id.Category,
       type: manyToManyModelType(Id.PostCategory),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: 'nMAVYlaMC77',
       alias: 'comments',
       sourceModelId: Id.Post,
       targetModelId: Id.PostComment,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: 'MXFKBquNNI6',
       alias: 'meta',
       sourceModelId: Id.Post,
       targetModelId: Id.PostMeta,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: 'UV43MPRd0Lt',
-      alias: null,
       sourceModelId: Id.Post,
       targetModelId: Id.PostTag,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: 'skZFJbJB6hh',
-      alias: null,
       sourceModelId: Id.Post,
       targetModelId: Id.Tag,
       type: manyToManyModelType(Id.PostTag),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const postCategory: Model = {
+const postCategory: Model = model({
   id: Id.PostCategory,
   name: 'post category',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
+    field({
       id: 'jdRrJjdcKkE',
       name: 'post id',
       type: bigIntDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: '3woIOm-7Iwk',
       name: 'category id',
       type: bigIntDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
+    association({
       id: '3woIOm-7Iwk',
-      alias: null,
       sourceModelId: Id.PostCategory,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: 'YN5x8WTSUv0',
-      alias: null,
       sourceModelId: Id.PostCategory,
       targetModelId: Id.Category,
       type: belongsToType(),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const postComment: Model = {
+const postComment: Model = model({
   id: Id.PostComment,
   name: 'post comment',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
+    field({
       id: 'pPx2dKSCxUU',
       name: 'id',
       type: bigIntDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'Unedw8_4esY',
       name: 'title',
       type: stringDataType({ length: 75 }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'py--ks_YQhk',
       name: 'published',
       type: booleanDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'AqsMlWfzsrp',
       name: 'published at',
       type: dateTimeDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'P_KCQh8vR4i',
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
+    association({
       id: 'w5mBh5K4X3W',
-      alias: null,
       sourceModelId: Id.PostComment,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: '57xLCZkr22k',
       alias: 'parent',
       sourceModelId: Id.PostComment,
       targetModelId: Id.PostComment,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: 'XZuWMYVjX9q',
       alias: 'children',
       sourceModelId: Id.PostComment,
       targetModelId: Id.PostComment,
       type: hasManyType(),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const postMeta: Model = {
+const postMeta: Model = model({
   id: Id.PostMeta,
   name: 'post meta',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
+    field({
       id: '_9jdNTR-39N',
       name: 'id',
       type: bigIntDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'u98W4zMVB7K',
       name: 'key',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
       required: true,
       unique: true,
-    },
-    {
+    }),
+    field({
       id: '_EqtSrP0p6x',
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
+    association({
       id: '0uE8EJCVIAD',
-      alias: null,
       sourceModelId: Id.PostMeta,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const postTag: Model = {
+const postTag: Model = model({
   id: Id.PostTag,
   name: 'post tag',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
+    field({
       id: 'wGszJWpxTPh',
       name: 'post id',
       type: bigIntDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'YlgLSgY8Skr',
       name: 'tag id',
       type: bigIntDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
+    association({
       id: '6Uh5opGS8LM',
-      alias: null,
       sourceModelId: Id.PostTag,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: 'xCR4XtTuYjT',
-      alias: null,
       sourceModelId: Id.PostTag,
       targetModelId: Id.Tag,
       type: belongsToType(),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const tag: Model = {
+const tag: Model = model({
   id: Id.Tag,
   name: 'tag',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
+    field({
       id: 'FshuF93yknb',
       name: 'id',
       type: bigIntDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: '8x7OAEK9LjG',
       name: 'title',
       type: stringDataType({ length: 75 }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'M2LEr5WWtYq',
       name: 'meta title',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'ePkkPVQvLF5',
       name: 'slug',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
       required: true,
       unique: true,
-    },
-    {
+    }),
+    field({
       id: 'eC71J1JAiW5',
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
+    association({
       id: 'Ch1tFcak4kC',
-      alias: null,
       sourceModelId: Id.Tag,
       targetModelId: Id.PostTag,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
+    }),
+    association({
       id: 'zUJ6zJEZ_TB',
-      alias: null,
       sourceModelId: Id.Tag,
       targetModelId: Id.Post,
       type: manyToManyModelType(Id.PostTag),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const user: Model = {
+const user: Model = model({
   id: Id.User,
   name: 'user',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
+    field({
       id: 'qjr5fhyBQJk',
       name: 'id',
       type: bigIntDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'QpCuohYW2Hs',
       name: 'first name',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: '4XJNERwnZG5',
       name: 'middle name',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'zG96hHN_eh2',
       name: 'last name',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: '8fYf5Z9TdLb',
       name: 'mobile',
       type: stringDataType({ length: 15 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'fKxR-4rs0UV',
       name: 'email',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'rcsZ85LnFsf',
       name: 'password hash',
       type: stringDataType({ length: 32 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'uHB2pNmoPGS',
       name: 'registered at',
       type: dateTimeDataType({ defaultNow: true }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: '_MA5Jrs0QRM',
       name: 'last login',
       type: dateTimeDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'tOGxTjl7N8V',
       name: 'intro',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
+    }),
+    field({
       id: 'X2g0Pw8QFq1',
       name: 'profile',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
+    association({
       id: 'pbNmGR7mt4P',
-      alias: null,
       sourceModelId: Id.User,
       targetModelId: Id.Post,
       type: hasManyType(),
       foreignKey: 'author id',
-    },
+    }),
   ],
-}
+})
 
-export const blogTranslatedFromV1: Schema = {
+export const blogTranslatedFromV1: Schema = schema({
   id: 'akwgxGmESSK',
   name: 'blog',
   createdAt: time,
   updatedAt: time,
-  forkedFrom: null,
   models: [category, post, postCategory, postComment, postMeta, postTag, tag, user],
-}
+})

--- a/src/api/schema/implementations/localStorage/index.ts
+++ b/src/api/schema/implementations/localStorage/index.ts
@@ -1,9 +1,16 @@
-import { Association, AssociationTypeType, Model, Schema, ThroughType } from '@src/core/schema'
+import {
+  Association,
+  AssociationTypeType,
+  Model,
+  Schema,
+  ThroughType,
+  manyToManyTableType,
+} from '@src/core/schema'
 import { arrayToLookup } from '@src/utils/array'
 import { now } from '@src/utils/dateTime'
 import { get, lsKey, remove, set } from '@src/utils/localStorage'
 import { uniqueId, versionedName } from '@src/utils/string'
-import { SchemaApi, SCHEMA_NOT_FOUND_ERROR } from '../../api'
+import { SCHEMA_NOT_FOUND_ERROR, SchemaApi } from '../../api'
 import * as Ids from '../../examples/ids'
 import { parseSchema, parseV0Lazy } from './parse'
 import { toV1 } from './v1/translate'
@@ -198,10 +205,7 @@ function joinModelToTable(
 
   return {
     ...association,
-    type: {
-      ...association.type,
-      through: { type: ThroughType.ThroughTable, table: `${nameA} ${nameB}` },
-    },
+    type: manyToManyTableType(`${nameA} ${nameB}`),
   }
 }
 

--- a/src/api/schema/implementations/localStorage/v0/translate.ts
+++ b/src/api/schema/implementations/localStorage/v0/translate.ts
@@ -1,70 +1,66 @@
 import {
-  arrayDataType,
   Association,
   AssociationType,
+  DataType,
+  Field,
+  Model,
+  Schema,
+  arrayDataType,
+  association,
   belongsToType,
   blobDataType,
   booleanDataType,
-  DataType,
   dateDataType,
   dateTimeDataType,
   decimalDataType,
   doubleDataType,
-  Field,
+  field,
   floatDataType,
   hasManyType,
   hasOneType,
   integerDataType,
   jsonDataType,
   manyToManyTableType,
-  Model,
+  model,
   realDataType,
-  Schema,
+  schema,
   stringDataType,
   textDataType,
   uuidDataType,
 } from '@src/core/schema'
-import { now } from '@src/utils/dateTime'
-import { uniqueId } from '@src/utils/string'
 import {
   Association as AssociationV0,
-  Field as FieldV0,
   FieldType,
+  Field as FieldV0,
   Model as ModelV0,
   SchemaV0,
 } from '.'
 
-export function fromV0(schema: SchemaV0): Schema {
-  return {
-    id: uniqueId(),
-    name: schema.config.name,
-    createdAt: now(),
-    updatedAt: now(),
-    forkedFrom: null,
-    models: schema.models.map(fromV0Model),
-  }
+export function fromV0(schemaV0: SchemaV0): Schema {
+  return schema({
+    name: schemaV0.config.name,
+    models: schemaV0.models.map(fromV0Model),
+  })
 }
 
-function fromV0Model(model: ModelV0): Model {
-  return {
-    id: model.id,
-    name: model.name,
-    fields: model.fields.map(fromV0Field),
-    associations: model.assocs.map(fromV0Association),
-    createdAt: now(),
-    updatedAt: now(),
-  }
+function fromV0Model(modelV0: ModelV0): Model {
+  return model({
+    id: modelV0.id,
+    name: modelV0.name,
+    fields: modelV0.fields.map(fromV0Field),
+    associations: modelV0.assocs.map(fromV0Association),
+  })
 }
 
-function fromV0Field(field: FieldV0): Field {
-  return {
-    id: field.id,
-    name: field.name,
-    type: fromV0DataType(field),
-    primaryKey: field.primaryKey,
-    required: field.required,
-    unique: field.unique,
-  }
+function fromV0Field(fieldV0: FieldV0): Field {
+  return field({
+    id: fieldV0.id,
+    name: fieldV0.name,
+    type: fromV0DataType(fieldV0),
+    primaryKey: fieldV0.primaryKey,
+    required: fieldV0.required,
+    unique: fieldV0.unique,
+  })
 }
 
 function fromV0DataType(field: FieldV0): DataType {
@@ -100,15 +96,15 @@ function fromV0DataType(field: FieldV0): DataType {
   }
 }
 
-function fromV0Association(association: AssociationV0): Association {
-  return {
-    id: association.id,
-    type: fromV0AssociationType(association),
-    sourceModelId: association.sourceId,
-    targetModelId: association.targetId,
-    foreignKey: association.foreignKey || null,
-    alias: association.name || null,
-  }
+function fromV0Association(associationV0: AssociationV0): Association {
+  return association({
+    id: associationV0.id,
+    type: fromV0AssociationType(associationV0),
+    sourceModelId: associationV0.sourceId,
+    targetModelId: associationV0.targetId,
+    foreignKey: associationV0.foreignKey || null,
+    alias: associationV0.name || null,
+  })
 }
 
 function fromV0AssociationType(association: AssociationV0): AssociationType {

--- a/src/api/schema/implementations/localStorage/v1/translate.ts
+++ b/src/api/schema/implementations/localStorage/v1/translate.ts
@@ -1,31 +1,35 @@
 import {
+  association,
   Association,
   AssociationType,
   belongsToType,
   DataType,
   DataTypeType,
+  field,
   Field,
   hasManyType,
   hasOneType,
   manyToManyModelType,
   manyToManyTableType,
+  model,
   Model,
+  schema,
   Schema,
   UuidType,
 } from '@src/core/schema'
 import {
-  Association as AssociationV1,
   AssociationType as AssociationTypeV1,
-  DataType as DataTypeV1,
+  Association as AssociationV1,
   DataTypeUuidDefaultVersion,
+  DataType as DataTypeV1,
   Field as FieldV1,
   Model as ModelV1,
   SchemaV1,
 } from '.'
 
-export function fromV1(schema: SchemaV1): Schema {
-  const models = schema.models.map(fromV1Model)
-  return { ...schema, forkedFrom: schema.forkedFrom ?? null, models }
+export function fromV1(schemaV1: SchemaV1): Schema {
+  const models = schemaV1.models.map(fromV1Model)
+  return schema({ ...schemaV1, forkedFrom: schemaV1.forkedFrom ?? null, models })
 }
 
 export function toV1(schema: Schema): SchemaV1 {
@@ -35,10 +39,10 @@ export function toV1(schema: Schema): SchemaV1 {
   }
 }
 
-function fromV1Model(model: ModelV1): Model {
-  const fields = model.fields.map(fromV1Field)
-  const associations = model.associations.map(fromV1Association)
-  return { ...model, fields, associations }
+function fromV1Model(modelV1: ModelV1): Model {
+  const fields = modelV1.fields.map(fromV1Field)
+  const associations = modelV1.associations.map(fromV1Association)
+  return model({ ...modelV1, fields, associations })
 }
 
 function toV1Model(model: Model): ModelV1 {
@@ -49,11 +53,11 @@ function toV1Model(model: Model): ModelV1 {
   }
 }
 
-function fromV1Field(field: FieldV1): Field {
-  return {
-    ...field,
-    type: fromV1DataType(field.type),
-  }
+function fromV1Field(fieldV1: FieldV1): Field {
+  return field({
+    ...fieldV1,
+    type: fromV1DataType(fieldV1.type),
+  })
 }
 
 function toV1Field(field: Field): FieldV1 {
@@ -192,13 +196,13 @@ function toV1UuidVersion(version: UuidType | null): DataTypeUuidDefaultVersion |
   }
 }
 
-function fromV1Association(association: AssociationV1): Association {
-  return {
-    ...association,
-    alias: association.alias ?? null,
-    foreignKey: association.foreignKey ?? null,
-    type: fromV1AssociationType(association.type),
-  }
+function fromV1Association(associationV1: AssociationV1): Association {
+  return association({
+    ...associationV1,
+    alias: associationV1.alias ?? null,
+    foreignKey: associationV1.foreignKey ?? null,
+    type: fromV1AssociationType(associationV1.type),
+  })
 }
 
 function toV1Association(association: Association): AssociationV1 {

--- a/src/api/userPreferences/examples/blog.ts
+++ b/src/api/userPreferences/examples/blog.ts
@@ -28,19 +28,22 @@
  *
  */
 import {
+  association,
   belongsToType,
   bigIntDataType,
   booleanDataType,
   dateTimeDataType,
+  field,
   hasManyType,
   manyToManyModelType,
+  model,
   Model,
+  schema,
   Schema,
   stringDataType,
   textDataType,
 } from '@src/core/schema'
 import { fromParts } from '@src/utils/dateTime'
-import { uniqueId } from '@src/utils/string'
 import { BLOG_ID } from './ids'
 
 const time = fromParts(2021, 4, 1)
@@ -56,557 +59,379 @@ enum Id {
   User = '6XfrfnVeY7KTKukt26dQZ',
 }
 
-const category: Model = {
+const category: Model = model({
   id: Id.Category,
   name: 'category',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'title',
       type: stringDataType({ length: 75 }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'meta title',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'slug',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
       required: true,
       unique: true,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
+    association({
       alias: 'parent',
       sourceModelId: Id.Category,
       targetModelId: Id.Category,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'children',
       sourceModelId: Id.Category,
       targetModelId: Id.Category,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.Category,
       targetModelId: Id.PostCategory,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.Category,
       targetModelId: Id.Post,
       type: manyToManyModelType(Id.PostCategory),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const post: Model = {
+const post: Model = model({
   id: Id.Post,
   name: 'post',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'title',
       type: stringDataType({ length: 75 }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'meta title',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'slug',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
       required: true,
       unique: true,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'summary',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'published',
       type: booleanDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'published at',
       type: dateTimeDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
+    association({
       alias: 'author',
       sourceModelId: Id.Post,
       targetModelId: Id.User,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'parent',
       sourceModelId: Id.Post,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'children',
       sourceModelId: Id.Post,
       targetModelId: Id.Post,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.Post,
       targetModelId: Id.PostCategory,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.Post,
       targetModelId: Id.Category,
       type: manyToManyModelType(Id.PostCategory),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'comments',
       sourceModelId: Id.Post,
       targetModelId: Id.PostComment,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'meta',
       sourceModelId: Id.Post,
       targetModelId: Id.PostMeta,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.Post,
       targetModelId: Id.PostTag,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.Post,
       targetModelId: Id.Tag,
       type: manyToManyModelType(Id.PostTag),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const postCategory: Model = {
+const postCategory: Model = model({
   id: Id.PostCategory,
   name: 'post category',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'category id',
       type: bigIntDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       sourceModelId: Id.PostCategory,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.PostCategory,
       targetModelId: Id.Category,
       type: belongsToType(),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const postComment: Model = {
+const postComment: Model = model({
   id: Id.PostComment,
   name: 'post comment',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'title',
       type: stringDataType({ length: 75 }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'published',
       type: booleanDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'published at',
       type: dateTimeDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       sourceModelId: Id.PostComment,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'parent',
       sourceModelId: Id.PostComment,
       targetModelId: Id.PostComment,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'children',
       sourceModelId: Id.PostComment,
       targetModelId: Id.PostComment,
       type: hasManyType(),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const postMeta: Model = {
+const postMeta: Model = model({
   id: Id.PostMeta,
   name: 'post meta',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'key',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
       required: true,
       unique: true,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       sourceModelId: Id.PostMeta,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const postTag: Model = {
+const postTag: Model = model({
   id: Id.PostTag,
   name: 'post tag',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'tag id',
       type: bigIntDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       sourceModelId: Id.PostTag,
       targetModelId: Id.Post,
       type: belongsToType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.PostTag,
       targetModelId: Id.Tag,
       type: belongsToType(),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const tag: Model = {
+const tag: Model = model({
   id: Id.Tag,
   name: 'tag',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'title',
       type: stringDataType({ length: 75 }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'meta title',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'slug',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
       required: true,
       unique: true,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'content',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       sourceModelId: Id.Tag,
       targetModelId: Id.PostTag,
       type: hasManyType(),
-      foreignKey: null,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       sourceModelId: Id.Tag,
       targetModelId: Id.Post,
       type: manyToManyModelType(Id.PostTag),
-      foreignKey: null,
-    },
+    }),
   ],
-}
+})
 
-const user: Model = {
+const user: Model = model({
   id: Id.User,
   name: 'user',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'first name',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'middle name',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'last name',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'mobile',
       type: stringDataType({ length: 15 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'email',
       type: stringDataType({ length: 50 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'password hash',
       type: stringDataType({ length: 32 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'registered at',
       type: dateTimeDataType({ defaultNow: true }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'last login',
       type: dateTimeDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'intro',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'profile',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       sourceModelId: Id.User,
       targetModelId: Id.Post,
       type: hasManyType(),
       foreignKey: 'author id',
-    },
+    }),
   ],
-}
+})
 
-const blogSchema: Schema = {
+const blogSchema: Schema = schema({
   id: BLOG_ID,
   name: 'blog',
   createdAt: time,
   updatedAt: time,
-  forkedFrom: null,
   models: [category, post, postCategory, postComment, postMeta, postTag, tag, user],
-}
+})
 
 export default blogSchema

--- a/src/api/userPreferences/examples/employees.ts
+++ b/src/api/userPreferences/examples/employees.ts
@@ -20,18 +20,21 @@
  *
  */
 import {
+  association,
   belongsToType,
   dateDataType,
   enumDataType,
+  field,
   hasManyType,
   integerDataType,
   manyToManyModelType,
+  model,
   Model,
+  schema,
   Schema,
   stringDataType,
 } from '@src/core/schema'
 import { fromParts } from '@src/utils/dateTime'
-import { uniqueId } from '@src/utils/string'
 import { EMPLOYEES_ID } from './ids'
 
 const time = fromParts(2020, 10, 1)
@@ -45,384 +48,294 @@ enum Id {
   Salaries = 'Xq55KHZ19UT9ob31iT_D_',
 }
 
-const employee: Model = {
+const employee: Model = model({
   id: Id.Employees,
   name: 'employees',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'emp_no',
       type: integerDataType({ autoincrement: true }),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'birth_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'first_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'last_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'gender',
       type: enumDataType({ values: ['M', 'F', 'O'] }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'hire_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       foreignKey: 'emp_no',
       type: hasManyType(),
       sourceModelId: Id.Employees,
       targetModelId: Id.Salaries,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       foreignKey: 'emp_no',
       type: hasManyType(),
       sourceModelId: Id.Employees,
       targetModelId: Id.Titles,
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'employingDepartment',
       foreignKey: 'emp_no',
       sourceModelId: Id.Employees,
       targetModelId: Id.Departments,
       type: manyToManyModelType(Id.DepartmentEmployees, 'dept_no'),
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'managedDepartment',
       foreignKey: 'emp_no',
       sourceModelId: Id.Employees,
       targetModelId: Id.Departments,
       type: manyToManyModelType(Id.DepartmentManagers, 'dept_no'),
-    },
+    }),
   ],
-}
+})
 
-const department: Model = {
+const department: Model = model({
   id: Id.Departments,
   name: 'departments',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'dept_no',
       type: stringDataType(),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'dept_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
+    association({
       alias: 'employee',
-      foreignKey: null,
       sourceModelId: Id.Departments,
       targetModelId: Id.Employees,
       type: manyToManyModelType(Id.DepartmentEmployees),
-    },
-    {
-      id: uniqueId(),
+    }),
+    association({
       alias: 'manager',
-      foreignKey: null,
       sourceModelId: Id.Departments,
       targetModelId: Id.Employees,
       type: manyToManyModelType(Id.DepartmentManagers),
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       foreignKey: 'dept_no',
       type: hasManyType(),
       sourceModelId: Id.Departments,
       targetModelId: Id.DepartmentEmployees,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       foreignKey: 'dept_no',
       type: hasManyType(),
       sourceModelId: Id.Departments,
       targetModelId: Id.DepartmentManagers,
-    },
+    }),
   ],
-}
+})
 
-const departmentEmployee: Model = {
+const departmentEmployee: Model = model({
   id: Id.DepartmentEmployees,
   name: 'dept_emp',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'emp_no',
       type: integerDataType(),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'dept_no',
       type: stringDataType(),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'from_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'to_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       foreignKey: 'emp_no',
       type: belongsToType(),
       sourceModelId: Id.DepartmentEmployees,
       targetModelId: Id.Employees,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       foreignKey: 'dept_no',
       type: belongsToType(),
       sourceModelId: Id.DepartmentEmployees,
       targetModelId: Id.Departments,
-    },
+    }),
   ],
-}
+})
 
-const departmentManager: Model = {
+const departmentManager: Model = model({
   id: Id.DepartmentManagers,
   name: 'dept_manager',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'emp_no',
       type: integerDataType(),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'dept_no',
       type: stringDataType(),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'from_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'to_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       foreignKey: 'emp_no',
       type: belongsToType(),
       sourceModelId: Id.DepartmentManagers,
       targetModelId: Id.Employees,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
+    }),
+    association({
       foreignKey: 'dept_no',
       type: belongsToType(),
       sourceModelId: Id.DepartmentManagers,
       targetModelId: Id.Departments,
-    },
+    }),
   ],
-}
+})
 
-const title: Model = {
+const title: Model = model({
   id: Id.Titles,
   name: 'titles',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'emp_no',
       type: integerDataType({ autoincrement: true }),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'title',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'from_date',
       type: dateDataType(),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'to_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       foreignKey: 'emp_no',
       type: belongsToType(),
       sourceModelId: Id.Titles,
       targetModelId: Id.Employees,
-    },
+    }),
   ],
-}
+})
 
-const salary: Model = {
+const salary: Model = model({
   id: Id.Salaries,
   name: 'salaries',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'emp_no',
       type: integerDataType({ autoincrement: true }),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'salary',
       type: integerDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'from_date',
       type: dateDataType(),
       primaryKey: true,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'to_date',
       type: dateDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
+    association({
       foreignKey: 'emp_no',
       type: belongsToType(),
       sourceModelId: Id.Salaries,
       targetModelId: Id.Employees,
-    },
+    }),
   ],
-}
+})
 
 // https://github.com/datacharmer/test_db
-const employeeSchema: Schema = {
+const employeeSchema: Schema = schema({
   id: EMPLOYEES_ID,
   name: 'employee dataset',
   createdAt: time,
   updatedAt: time,
-  forkedFrom: null,
   models: [employee, department, departmentEmployee, departmentManager, title, salary],
-}
+})
 
 export default employeeSchema

--- a/src/api/userPreferences/examples/sakila.ts
+++ b/src/api/userPreferences/examples/sakila.ts
@@ -21,6 +21,7 @@
 
 import {
   arrayDataType,
+  association,
   belongsToType,
   blobDataType,
   booleanDataType,
@@ -28,16 +29,18 @@ import {
   dateTimeDataType,
   decimalDataType,
   enumDataType,
+  field,
   hasManyType,
   hasOneType,
   integerDataType,
   manyToManyModelType,
+  model,
   Model,
+  schema,
   Schema,
   stringDataType,
 } from '@src/core/schema'
 import { fromParts } from '@src/utils/dateTime'
-import { uniqueId } from '@src/utils/string'
 import { SAKILA_ID } from './ids'
 
 const time = fromParts(2020, 1, 1)
@@ -61,793 +64,427 @@ enum Id {
   Store = 'SKfg8yJLz5XTlCWRuQgMo',
 }
 
-const actor: Model = {
+const actor: Model = model({
   id: Id.Actor,
   name: 'actor',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'first_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'last_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: 'actor_id',
+    association({
+      type: manyToManyModelType(Id.FilmActor, 'film_id'),
       sourceModelId: Id.Actor,
       targetModelId: Id.Film,
-      type: manyToManyModelType(Id.FilmActor, 'film_id'),
-    },
+      foreignKey: 'actor_id',
+    }),
   ],
-}
+})
 
-const film: Model = {
+const film: Model = model({
   id: Id.Film,
   name: 'film',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'title',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'description',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'release_year',
       type: integerDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'language_id',
       type: integerDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'original_language_id',
       type: integerDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'rental_duration',
       type: integerDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'rental_rate',
       type: decimalDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'length',
       type: integerDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'rating',
       type: enumDataType({ values: ['G', 'PG', 'PG-13', 'R', 'NC-17'] }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'special_feature',
       type: arrayDataType({
         arrayType: enumDataType({
           values: ['Trailers', 'Commentaries', 'Deleted Scenes', 'Behind the Scenes'],
         }),
       }),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({ type: belongsToType(), sourceModelId: Id.Film, targetModelId: Id.Language }),
+    association({
       type: belongsToType(),
       sourceModelId: Id.Film,
       targetModelId: Id.Language,
-    },
-    {
-      id: uniqueId(),
       alias: 'original_language',
       foreignKey: 'original_language_id',
-      type: belongsToType(),
-      sourceModelId: Id.Film,
-      targetModelId: Id.Language,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: 'film_id',
+    }),
+    association({
       type: hasManyType(),
       sourceModelId: Id.Film,
       targetModelId: Id.Inventory,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
       foreignKey: 'film_id',
+    }),
+    association({
+      type: manyToManyModelType(Id.FilmActor, 'actor_id'),
       sourceModelId: Id.Film,
       targetModelId: Id.Actor,
-      type: manyToManyModelType(Id.FilmActor, 'actor_id'),
-    },
-    {
-      id: uniqueId(),
-      alias: null,
       foreignKey: 'film_id',
+    }),
+    association({
+      type: manyToManyModelType(Id.FilmCategory, 'category_id'),
       sourceModelId: Id.Film,
       targetModelId: Id.Category,
-      type: manyToManyModelType(Id.FilmCategory, 'category_id'),
-    },
+      foreignKey: 'film_id',
+    }),
   ],
-}
+})
 
-const language: Model = {
+const language: Model = model({
   id: Id.Language,
   name: 'language',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({ type: hasManyType(), sourceModelId: Id.Language, targetModelId: Id.Film }),
+    association({
       type: hasManyType(),
       sourceModelId: Id.Language,
       targetModelId: Id.Film,
-    },
-    {
-      id: uniqueId(),
       alias: 'original_language_film',
       foreignKey: 'original_language_id',
-      type: hasManyType(),
-      sourceModelId: Id.Language,
-      targetModelId: Id.Film,
-    },
+    }),
   ],
-}
+})
 
-const category: Model = {
+const category: Model = model({
   id: Id.Category,
   name: 'category',
   createdAt: time,
   updatedAt: time,
-  fields: [],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: 'category_id',
+    association({
+      type: manyToManyModelType(Id.FilmCategory, 'film_id'),
       sourceModelId: Id.Category,
       targetModelId: Id.Film,
-      type: manyToManyModelType(Id.FilmCategory, 'film_id'),
-    },
+      foreignKey: 'category_id',
+    }),
   ],
-}
+})
 
-const inventory: Model = {
+const inventory: Model = model({
   id: Id.Inventory,
   name: 'inventory',
   createdAt: time,
   updatedAt: time,
-  fields: [],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      sourceModelId: Id.Inventory,
-      targetModelId: Id.Film,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      sourceModelId: Id.Inventory,
-      targetModelId: Id.Store,
-    },
+    association({ type: belongsToType(), sourceModelId: Id.Inventory, targetModelId: Id.Film }),
+    association({ type: belongsToType(), sourceModelId: Id.Inventory, targetModelId: Id.Store }),
   ],
-}
+})
 
-const store: Model = {
+const store: Model = model({
   id: Id.Store,
   name: 'store',
   createdAt: time,
   updatedAt: time,
-  fields: [],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: hasManyType(),
-      sourceModelId: Id.Store,
-      targetModelId: Id.Inventory,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: hasManyType(),
+    association({ type: hasManyType(), sourceModelId: Id.Store, targetModelId: Id.Inventory }),
+    association({ type: hasManyType(), sourceModelId: Id.Store, targetModelId: Id.Staff }),
+    association({ type: hasManyType(), sourceModelId: Id.Store, targetModelId: Id.Customer }),
+    association({
+      type: belongsToType(),
       sourceModelId: Id.Store,
       targetModelId: Id.Staff,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: hasManyType(),
-      sourceModelId: Id.Store,
-      targetModelId: Id.Customer,
-    },
-    {
-      id: uniqueId(),
       alias: 'manager',
       foreignKey: 'manager_staff_id',
-      type: belongsToType(),
-      sourceModelId: Id.Store,
-      targetModelId: Id.Staff,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      sourceModelId: Id.Store,
-      targetModelId: Id.Address,
-    },
+    }),
+    association({ type: belongsToType(), sourceModelId: Id.Store, targetModelId: Id.Address }),
   ],
-}
+})
 
-const staff: Model = {
+const staff: Model = model({
   id: Id.Staff,
   name: 'staff',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'first_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'last_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'picture',
       type: blobDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'email',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'active',
       type: booleanDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'username',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'password',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      targetModelId: Id.Store,
-      sourceModelId: Id.Staff,
-    },
-    {
-      id: uniqueId(),
+    association({ type: belongsToType(), sourceModelId: Id.Store, targetModelId: Id.Staff }),
+    association({
+      type: hasManyType(),
+      sourceModelId: Id.Store,
+      targetModelId: Id.Staff,
       alias: 'managed_store',
       foreignKey: 'manager_staff_id',
-      type: hasManyType(),
-      targetModelId: Id.Store,
-      sourceModelId: Id.Staff,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      targetModelId: Id.Address,
-      sourceModelId: Id.Staff,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: hasManyType(),
-      targetModelId: Id.Rental,
-      sourceModelId: Id.Staff,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: hasManyType(),
-      targetModelId: Id.Payment,
-      sourceModelId: Id.Staff,
-    },
+    }),
+    association({ type: belongsToType(), sourceModelId: Id.Address, targetModelId: Id.Staff }),
+    association({ type: hasManyType(), sourceModelId: Id.Rental, targetModelId: Id.Staff }),
+    association({ type: hasManyType(), sourceModelId: Id.Payment, targetModelId: Id.Staff }),
   ],
-}
+})
 
-const customer: Model = {
+const customer: Model = model({
   id: Id.Customer,
   name: 'customer',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'first_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'last_name',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'email',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'active',
       type: booleanDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      targetModelId: Id.Store,
-      sourceModelId: Id.Customer,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      targetModelId: Id.Address,
-      sourceModelId: Id.Customer,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: hasManyType(),
-      targetModelId: Id.Rental,
-      sourceModelId: Id.Customer,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: hasManyType(),
-      targetModelId: Id.Payment,
-      sourceModelId: Id.Customer,
-    },
+    association({ type: belongsToType(), sourceModelId: Id.Store, targetModelId: Id.Customer }),
+    association({ type: belongsToType(), sourceModelId: Id.Address, targetModelId: Id.Customer }),
+    association({ type: hasManyType(), sourceModelId: Id.Rental, targetModelId: Id.Customer }),
+    association({ type: hasManyType(), sourceModelId: Id.Payment, targetModelId: Id.Customer }),
   ],
-}
+})
 
-const address: Model = {
+const address: Model = model({
   id: Id.Address,
   name: 'address',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'address',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'address2',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'postal_code',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'phone',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      targetModelId: Id.City,
-      sourceModelId: Id.Address,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: hasOneType(),
-      targetModelId: Id.Customer,
-      sourceModelId: Id.Address,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: hasOneType(),
-      targetModelId: Id.Staff,
-      sourceModelId: Id.Address,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: hasOneType(),
-      targetModelId: Id.Store,
-      sourceModelId: Id.Address,
-    },
+    association({ type: belongsToType(), sourceModelId: Id.City, targetModelId: Id.Address }),
+    association({ type: hasOneType(), sourceModelId: Id.Customer, targetModelId: Id.Address }),
+    association({ type: hasOneType(), sourceModelId: Id.Staff, targetModelId: Id.Address }),
+    association({ type: hasOneType(), sourceModelId: Id.Store, targetModelId: Id.Address }),
   ],
-}
+})
 
-const rental: Model = {
+const rental: Model = model({
   id: Id.Rental,
   name: 'rental',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'rental_date',
       type: dateDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'return_date',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      targetModelId: Id.Inventory,
-      sourceModelId: Id.Rental,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      targetModelId: Id.Customer,
-      sourceModelId: Id.Rental,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      targetModelId: Id.Staff,
-      sourceModelId: Id.Rental,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: hasManyType(),
-      targetModelId: Id.Payment,
-      sourceModelId: Id.Rental,
-    },
+    association({ type: belongsToType(), sourceModelId: Id.Inventory, targetModelId: Id.Rental }),
+    association({ type: belongsToType(), sourceModelId: Id.Customer, targetModelId: Id.Rental }),
+    association({ type: belongsToType(), sourceModelId: Id.Staff, targetModelId: Id.Rental }),
+    association({ type: hasManyType(), sourceModelId: Id.Payment, targetModelId: Id.Rental }),
   ],
-}
+})
 
-const payment: Model = {
+const payment: Model = model({
   id: Id.Payment,
   name: 'payment',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'amount',
       type: decimalDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'payment_date',
       type: dateTimeDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      targetModelId: Id.Customer,
-      sourceModelId: Id.Payment,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      targetModelId: Id.Staff,
-      sourceModelId: Id.Payment,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      targetModelId: Id.Rental,
-      sourceModelId: Id.Payment,
-    },
+    association({ type: belongsToType(), sourceModelId: Id.Customer, targetModelId: Id.Payment }),
+    association({ type: belongsToType(), sourceModelId: Id.Staff, targetModelId: Id.Payment }),
+    association({ type: belongsToType(), sourceModelId: Id.Rental, targetModelId: Id.Payment }),
   ],
-}
+})
 
-const city: Model = {
+const city: Model = model({
   id: Id.City,
   name: 'city',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'city',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      targetModelId: Id.Country,
-      sourceModelId: Id.City,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: hasManyType(),
-      targetModelId: Id.Address,
-      sourceModelId: Id.City,
-    },
+    association({ type: belongsToType(), sourceModelId: Id.Country, targetModelId: Id.City }),
+    association({ type: hasManyType(), sourceModelId: Id.Address, targetModelId: Id.City }),
   ],
-}
+})
 
-const country: Model = {
+const country: Model = model({
   id: Id.Country,
   name: 'country',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'country',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: hasManyType(),
-      targetModelId: Id.City,
-      sourceModelId: Id.Country,
-    },
+    association({ type: hasManyType(), sourceModelId: Id.City, targetModelId: Id.Country }),
   ],
-}
+})
 
-const film_actor: Model = {
+const film_actor: Model = model({
   id: Id.FilmActor,
   name: 'film_actor',
   createdAt: time,
   updatedAt: time,
-  fields: [],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      sourceModelId: Id.FilmActor,
-      targetModelId: Id.Film,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      sourceModelId: Id.FilmActor,
-      targetModelId: Id.Actor,
-    },
+    association({ type: belongsToType(), sourceModelId: Id.FilmActor, targetModelId: Id.Film }),
+    association({ type: belongsToType(), sourceModelId: Id.FilmActor, targetModelId: Id.Actor }),
   ],
-}
+})
 
-const film_category: Model = {
+const film_category: Model = model({
   id: Id.FilmCategory,
   name: 'film_category',
   createdAt: time,
   updatedAt: time,
-  fields: [],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      type: belongsToType(),
-      sourceModelId: Id.FilmCategory,
-      targetModelId: Id.Film,
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({ type: belongsToType(), sourceModelId: Id.FilmCategory, targetModelId: Id.Film }),
+    association({
       type: belongsToType(),
       sourceModelId: Id.FilmCategory,
       targetModelId: Id.Category,
-    },
+    }),
   ],
-}
+})
 
 // https://dev.mysql.com/doc/sakila/en/
-const sakilaSchema: Schema = {
+const sakilaSchema: Schema = schema({
   id: SAKILA_ID,
   name: 'sakila',
   createdAt: time,
   updatedAt: time,
-  forkedFrom: null,
   models: [
     actor,
     film,
@@ -865,6 +502,6 @@ const sakilaSchema: Schema = {
     film_actor,
     film_category,
   ],
-}
+})
 
 export default sakilaSchema

--- a/src/core/schema/__tests__/__fixtures__/association.ts
+++ b/src/core/schema/__tests__/__fixtures__/association.ts
@@ -13,46 +13,32 @@ import {
 
 export const belongsToType_: BelongsToAssociation = {
   type: AssociationTypeType.BelongsTo,
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false,
 }
 export const hasManyType_: HasManyAssociation = {
   type: AssociationTypeType.HasMany,
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false,
 }
 export const hasOneType_: HasOneAssociation = {
   type: AssociationTypeType.HasOne,
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false,
 }
 export const throughTable_: ManyToManyThroughTable = {
   type: ThroughType.ThroughTable,
   table: 'foo',
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false,
 }
 
 export const throughModel_: ManyToManyThroughModel = {
   type: ThroughType.ThroughModel,
   modelId: uniqueId(),
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false,
 }
 
 export const manyToManyTableType_: ManyToManyAssociation = {
   type: AssociationTypeType.ManyToMany,
   through: throughTable_,
   targetFk: null,
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false,
 }
 export const manyToManyModelType_: ManyToManyAssociation = {
   type: AssociationTypeType.ManyToMany,
   through: throughModel_,
   targetFk: null,
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false,
 }
 
 export const baseAssociation: Omit<Association, 'type'> = {
@@ -61,8 +47,6 @@ export const baseAssociation: Omit<Association, 'type'> = {
   foreignKey: null,
   sourceModelId: uniqueId(),
   targetModelId: uniqueId(),
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false,
 }
 
 export const belongsTo: Association<BelongsToAssociation> = {

--- a/src/core/schema/__tests__/__fixtures__/association.ts
+++ b/src/core/schema/__tests__/__fixtures__/association.ts
@@ -11,28 +11,48 @@ import {
   ThroughType,
 } from '../../association'
 
-export const belongsToType_: BelongsToAssociation = { type: AssociationTypeType.BelongsTo }
-export const hasManyType_: HasManyAssociation = { type: AssociationTypeType.HasMany }
-export const hasOneType_: HasOneAssociation = { type: AssociationTypeType.HasOne }
+export const belongsToType_: BelongsToAssociation = {
+  type: AssociationTypeType.BelongsTo,
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false,
+}
+export const hasManyType_: HasManyAssociation = {
+  type: AssociationTypeType.HasMany,
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false,
+}
+export const hasOneType_: HasOneAssociation = {
+  type: AssociationTypeType.HasOne,
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false,
+}
 export const throughTable_: ManyToManyThroughTable = {
   type: ThroughType.ThroughTable,
   table: 'foo',
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false,
 }
 
 export const throughModel_: ManyToManyThroughModel = {
   type: ThroughType.ThroughModel,
   modelId: uniqueId(),
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false,
 }
 
 export const manyToManyTableType_: ManyToManyAssociation = {
   type: AssociationTypeType.ManyToMany,
   through: throughTable_,
   targetFk: null,
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false,
 }
 export const manyToManyModelType_: ManyToManyAssociation = {
   type: AssociationTypeType.ManyToMany,
   through: throughModel_,
   targetFk: null,
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false,
 }
 
 export const baseAssociation: Omit<Association, 'type'> = {
@@ -41,6 +61,8 @@ export const baseAssociation: Omit<Association, 'type'> = {
   foreignKey: null,
   sourceModelId: uniqueId(),
   targetModelId: uniqueId(),
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false,
 }
 
 export const belongsTo: Association<BelongsToAssociation> = {

--- a/src/core/schema/__tests__/associations.spec.ts
+++ b/src/core/schema/__tests__/associations.spec.ts
@@ -21,6 +21,7 @@ import {
   manyToManyTableType,
   ThroughType,
 } from '../association'
+import { association } from '../schema'
 import {
   belongsTo,
   belongsToType_,
@@ -169,86 +170,68 @@ describe('schema dataTypes', () => {
   })
 
   describe('associationIsCircular', () => {
-    const aBelongsToB: Association<BelongsToAssociation> = {
+    const aBelongsToB: Association<BelongsToAssociation> = association({
       id: 'aBelongsToB',
-      alias: null,
-      foreignKey: null,
       sourceModelId: 'a',
       targetModelId: 'b',
       type: belongsToType(),
-    }
+    })
 
-    const aHasManyB: Association<HasManyAssociation> = {
+    const aHasManyB: Association<HasManyAssociation> = association({
       id: 'aHasManyB',
-      alias: null,
-      foreignKey: null,
       sourceModelId: 'a',
       targetModelId: 'b',
       type: hasManyType(),
-    }
+    })
 
-    const aHasOneB: Association<HasOneAssociation> = {
+    const aHasOneB: Association<HasOneAssociation> = association({
       id: 'aHasOneB',
-      alias: null,
-      foreignKey: null,
       sourceModelId: 'a',
       targetModelId: 'b',
       type: hasOneType(),
-    }
+    })
 
-    const bBelongsToA: Association<BelongsToAssociation> = {
+    const bBelongsToA: Association<BelongsToAssociation> = association({
       id: 'bBelongsToA',
-      alias: null,
-      foreignKey: null,
       sourceModelId: 'b',
       targetModelId: 'a',
       type: belongsToType(),
-    }
+    })
 
-    const bHasManyA: Association<HasManyAssociation> = {
+    const bHasManyA: Association<HasManyAssociation> = association({
       id: 'bHasManyA',
-      alias: null,
-      foreignKey: null,
       sourceModelId: 'b',
       targetModelId: 'a',
       type: hasManyType(),
-    }
+    })
 
-    const bHasOneA: Association<HasManyAssociation> = {
+    const bHasOneA: Association<HasManyAssociation> = association({
       id: 'bHasOneA',
-      alias: null,
-      foreignKey: null,
       sourceModelId: 'b',
       targetModelId: 'a',
       type: hasManyType(),
-    }
+    })
 
-    const aBelongsToC: Association<BelongsToAssociation> = {
+    const aBelongsToC: Association<BelongsToAssociation> = association({
       id: 'aBelongsToC',
-      alias: null,
-      foreignKey: null,
       sourceModelId: 'a',
       targetModelId: 'c',
       type: belongsToType(),
-    }
+    })
 
-    const aManyToManyB: Association<ManyToManyAssociation> = {
+    const aManyToManyB: Association<ManyToManyAssociation> = association({
       id: 'aManyToManyB',
-      alias: null,
-      foreignKey: null,
       sourceModelId: 'a',
       targetModelId: 'b',
       type: manyToManyTableType('foo'),
-    }
+    })
 
-    const bManyToManyA: Association<ManyToManyAssociation> = {
+    const bManyToManyA: Association<ManyToManyAssociation> = association({
       id: 'bManyToManyA',
-      alias: null,
-      foreignKey: null,
       sourceModelId: 'b',
       targetModelId: 'a',
       type: manyToManyTableType('bar'),
-    }
+    })
 
     const commonAssociations = [aBelongsToC, aManyToManyB, bManyToManyA]
 

--- a/src/core/schema/association.ts
+++ b/src/core/schema/association.ts
@@ -7,8 +7,6 @@ export type Association<T extends AssociationType = AssociationType> = {
   targetModelId: string
   foreignKey: string | null
   alias: string | null
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false
 }
 
 export enum AssociationTypeType {
@@ -24,28 +22,14 @@ export type AssociationType =
   | HasManyAssociation
   | ManyToManyAssociation
 
-export type BelongsToAssociation = {
-  type: AssociationTypeType.BelongsTo
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false
-}
-export type HasOneAssociation = {
-  type: AssociationTypeType.HasOne
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false
-}
-export type HasManyAssociation = {
-  type: AssociationTypeType.HasMany
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false
-}
+export type BelongsToAssociation = { type: AssociationTypeType.BelongsTo }
+export type HasOneAssociation = { type: AssociationTypeType.HasOne }
+export type HasManyAssociation = { type: AssociationTypeType.HasMany }
 
 export type ManyToManyAssociation = {
   type: AssociationTypeType.ManyToMany
   through: ManyToManyThrough
   targetFk: string | null
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false
 }
 
 export type ManyToManyThrough = ManyToManyThroughModel | ManyToManyThroughTable
@@ -53,15 +37,11 @@ export type ManyToManyThrough = ManyToManyThroughModel | ManyToManyThroughTable
 export type ManyToManyThroughModel = {
   type: ThroughType.ThroughModel
   modelId: string
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false
 }
 
 export type ManyToManyThroughTable = {
   type: ThroughType.ThroughTable
   table: string
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false
 }
 
 export enum ThroughType {
@@ -111,44 +91,25 @@ export function associationTypeIsPlural(type: AssociationType): boolean {
 }
 
 export function belongsToType(): BelongsToAssociation {
-  return {
-    type: AssociationTypeType.BelongsTo,
-    // TODO: remove after switching to use constructor everywhere
-    __throwaway__: false,
-  }
+  return { type: AssociationTypeType.BelongsTo }
 }
 
 export function hasManyType(): HasManyAssociation {
-  return {
-    type: AssociationTypeType.HasMany,
-    // TODO: remove after switching to use constructor everywhere
-    __throwaway__: false,
-  }
+  return { type: AssociationTypeType.HasMany }
 }
 
 export function hasOneType(): HasOneAssociation {
-  return {
-    type: AssociationTypeType.HasOne,
-    // TODO: remove after switching to use constructor everywhere
-    __throwaway__: false,
-  }
+  return { type: AssociationTypeType.HasOne }
 }
 
 export function throughTable(table: string): ManyToManyThrough {
-  return {
-    type: ThroughType.ThroughTable,
-    table,
-    // TODO: remove after switching to use constructor everywhere
-    __throwaway__: false,
-  }
+  return { type: ThroughType.ThroughTable, table }
 }
 
 export function throughModel(modelId: string): ManyToManyThrough {
   return {
     type: ThroughType.ThroughModel,
     modelId,
-    // TODO: remove after switching to use constructor everywhere
-    __throwaway__: false,
   }
 }
 
@@ -160,8 +121,6 @@ export function manyToManyTableType(
     type: AssociationTypeType.ManyToMany,
     through: throughTable(table),
     targetFk,
-    // TODO: remove after switching to use constructor everywhere
-    __throwaway__: false,
   }
 }
 
@@ -173,8 +132,6 @@ export function manyToManyModelType(
     type: AssociationTypeType.ManyToMany,
     through: throughModel(modelId),
     targetFk,
-    // TODO: remove after switching to use constructor everywhere
-    __throwaway__: false,
   }
 }
 

--- a/src/core/schema/association.ts
+++ b/src/core/schema/association.ts
@@ -7,6 +7,8 @@ export type Association<T extends AssociationType = AssociationType> = {
   targetModelId: string
   foreignKey: string | null
   alias: string | null
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false
 }
 
 export enum AssociationTypeType {
@@ -22,14 +24,28 @@ export type AssociationType =
   | HasManyAssociation
   | ManyToManyAssociation
 
-export type BelongsToAssociation = { type: AssociationTypeType.BelongsTo }
-export type HasOneAssociation = { type: AssociationTypeType.HasOne }
-export type HasManyAssociation = { type: AssociationTypeType.HasMany }
+export type BelongsToAssociation = {
+  type: AssociationTypeType.BelongsTo
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false
+}
+export type HasOneAssociation = {
+  type: AssociationTypeType.HasOne
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false
+}
+export type HasManyAssociation = {
+  type: AssociationTypeType.HasMany
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false
+}
 
 export type ManyToManyAssociation = {
   type: AssociationTypeType.ManyToMany
   through: ManyToManyThrough
   targetFk: string | null
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false
 }
 
 export type ManyToManyThrough = ManyToManyThroughModel | ManyToManyThroughTable
@@ -37,11 +53,15 @@ export type ManyToManyThrough = ManyToManyThroughModel | ManyToManyThroughTable
 export type ManyToManyThroughModel = {
   type: ThroughType.ThroughModel
   modelId: string
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false
 }
 
 export type ManyToManyThroughTable = {
   type: ThroughType.ThroughTable
   table: string
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false
 }
 
 export enum ThroughType {
@@ -91,25 +111,44 @@ export function associationTypeIsPlural(type: AssociationType): boolean {
 }
 
 export function belongsToType(): BelongsToAssociation {
-  return { type: AssociationTypeType.BelongsTo }
+  return {
+    type: AssociationTypeType.BelongsTo,
+    // TODO: remove after switching to use constructor everywhere
+    __throwaway__: false,
+  }
 }
 
 export function hasManyType(): HasManyAssociation {
-  return { type: AssociationTypeType.HasMany }
+  return {
+    type: AssociationTypeType.HasMany,
+    // TODO: remove after switching to use constructor everywhere
+    __throwaway__: false,
+  }
 }
 
 export function hasOneType(): HasOneAssociation {
-  return { type: AssociationTypeType.HasOne }
+  return {
+    type: AssociationTypeType.HasOne,
+    // TODO: remove after switching to use constructor everywhere
+    __throwaway__: false,
+  }
 }
 
 export function throughTable(table: string): ManyToManyThrough {
-  return { type: ThroughType.ThroughTable, table }
+  return {
+    type: ThroughType.ThroughTable,
+    table,
+    // TODO: remove after switching to use constructor everywhere
+    __throwaway__: false,
+  }
 }
 
 export function throughModel(modelId: string): ManyToManyThrough {
   return {
     type: ThroughType.ThroughModel,
     modelId,
+    // TODO: remove after switching to use constructor everywhere
+    __throwaway__: false,
   }
 }
 
@@ -121,6 +160,8 @@ export function manyToManyTableType(
     type: AssociationTypeType.ManyToMany,
     through: throughTable(table),
     targetFk,
+    // TODO: remove after switching to use constructor everywhere
+    __throwaway__: false,
   }
 }
 
@@ -132,6 +173,8 @@ export function manyToManyModelType(
     type: AssociationTypeType.ManyToMany,
     through: throughModel(modelId),
     targetFk,
+    // TODO: remove after switching to use constructor everywhere
+    __throwaway__: false,
   }
 }
 

--- a/src/core/schema/schema.ts
+++ b/src/core/schema/schema.ts
@@ -12,8 +12,6 @@ export type Schema = {
   forkedFrom: string | null
   createdAt: string
   updatedAt: string
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false
 }
 
 export type Model = {
@@ -23,8 +21,6 @@ export type Model = {
   associations: Association[]
   createdAt: string
   updatedAt: string
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false
 }
 
 export type Field = {
@@ -34,8 +30,6 @@ export type Field = {
   primaryKey: boolean
   required: boolean
   unique: boolean
-  // TODO: remove after switching to use constructor everywhere
-  __throwaway__: false
 }
 
 export function emptySchema(): Schema {
@@ -47,8 +41,6 @@ export function emptySchema(): Schema {
     forkedFrom: null,
     createdAt: time,
     updatedAt: time,
-    // TODO: remove after switching to use constructor everywhere
-    __throwaway__: false,
   }
 }
 
@@ -65,8 +57,6 @@ export function emptyModel(): Model {
     associations: [],
     createdAt: time,
     updatedAt: time,
-    // TODO: remove after switching to use constructor everywhere
-    __throwaway__: false,
   }
 }
 
@@ -82,7 +72,6 @@ export function emptyField(): Field {
     primaryKey: false,
     required: false,
     unique: false,
-    __throwaway__: false,
   }
 }
 
@@ -104,7 +93,6 @@ export function emptyAssociation(
     targetModelId,
     foreignKey: null,
     alias: null,
-    __throwaway__: false,
   }
 }
 

--- a/src/core/schema/schema.ts
+++ b/src/core/schema/schema.ts
@@ -1,7 +1,8 @@
 import { now } from '@src/utils/dateTime'
 import { uniqueId } from '@src/utils/string'
+import { AtLeast } from '@src/utils/types'
 import { stringDataType } from '.'
-import { Association, AssociationTypeType } from './association'
+import { Association, AssociationType, belongsToType } from './association'
 import { DataType } from './dataType'
 
 export type Schema = {
@@ -11,6 +12,8 @@ export type Schema = {
   forkedFrom: string | null
   createdAt: string
   updatedAt: string
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false
 }
 
 export type Model = {
@@ -20,6 +23,8 @@ export type Model = {
   associations: Association[]
   createdAt: string
   updatedAt: string
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false
 }
 
 export type Field = {
@@ -29,6 +34,8 @@ export type Field = {
   primaryKey: boolean
   required: boolean
   unique: boolean
+  // TODO: remove after switching to use constructor everywhere
+  __throwaway__: false
 }
 
 export function emptySchema(): Schema {
@@ -40,7 +47,13 @@ export function emptySchema(): Schema {
     forkedFrom: null,
     createdAt: time,
     updatedAt: time,
+    // TODO: remove after switching to use constructor everywhere
+    __throwaway__: false,
   }
+}
+
+export function schema(attrs: AtLeast<Schema, 'name'>): Schema {
+  return { ...emptySchema(), ...attrs }
 }
 
 export function emptyModel(): Model {
@@ -52,7 +65,13 @@ export function emptyModel(): Model {
     associations: [],
     createdAt: time,
     updatedAt: time,
+    // TODO: remove after switching to use constructor everywhere
+    __throwaway__: false,
   }
+}
+
+export function model(attrs: AtLeast<Model, 'name'>): Model {
+  return { ...emptyModel(), ...attrs }
 }
 
 export function emptyField(): Field {
@@ -63,10 +82,11 @@ export function emptyField(): Field {
     primaryKey: false,
     required: false,
     unique: false,
+    __throwaway__: false,
   }
 }
 
-export function field(props: Partial<Field> = {}): Field {
+export function field(props: AtLeast<Field, 'name' | 'type'>): Field {
   return {
     ...emptyField(),
     ...props,
@@ -80,19 +100,18 @@ export function emptyAssociation(
   return {
     id: uniqueId(),
     sourceModelId,
-    type: { type: AssociationTypeType.BelongsTo },
+    type: belongsToType(),
     targetModelId,
     foreignKey: null,
     alias: null,
+    __throwaway__: false,
   }
 }
 
-export function association(
-  sourceModelId: Model['id'],
-  targetModelId: Model['id'],
-  props: Partial<Association>,
-): Association {
-  return { ...emptyAssociation(sourceModelId, targetModelId), ...props }
+export function association<T extends AssociationType>(
+  props: AtLeast<Association<T>, 'sourceModelId' | 'targetModelId' | 'type'>,
+): Association<T> {
+  return { ...emptyAssociation(props.sourceModelId, props.targetModelId), ...props }
 }
 
 export function isNewSchema(schema: Schema): boolean {

--- a/src/frameworks/__fixtures__/schemas/associations.ts
+++ b/src/frameworks/__fixtures__/schemas/associations.ts
@@ -1,10 +1,14 @@
 import {
+  association,
   belongsToType,
   bigIntDataType,
+  field,
   hasManyType,
   manyToManyModelType,
   manyToManyTableType,
+  model,
   Model,
+  schema,
   Schema,
 } from '@src/core/schema'
 import { fromParts } from '@src/utils/dateTime'
@@ -20,208 +24,129 @@ const Id = {
   Tag: uniqueId(),
 } as const
 
-const category: Model = {
+const category: Model = model({
   id: Id.Category,
   name: 'category',
   createdAt: time,
   updatedAt: time,
-  fields: [],
   associations: [
-    {
-      id: uniqueId(),
+    association({
+      sourceModelId: Id.Category,
+      targetModelId: Id.Category,
       alias: 'parent',
-      foreignKey: null,
-      sourceModelId: Id.Category,
-      targetModelId: Id.Category,
       type: belongsToType(),
-    },
-    {
-      id: uniqueId(),
-      alias: 'children',
-      foreignKey: null,
+    }),
+    association({
       sourceModelId: Id.Category,
       targetModelId: Id.Category,
+      alias: 'children',
       type: hasManyType(),
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       sourceModelId: Id.Category,
       targetModelId: Id.PostCategory,
       type: hasManyType(),
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({
       sourceModelId: Id.Category,
       targetModelId: Id.Post,
       type: manyToManyModelType(Id.PostCategory),
-    },
+    }),
   ],
-}
+})
 
-const post: Model = {
+const post: Model = model({
   id: Id.Post,
   name: 'post',
   createdAt: time,
   updatedAt: time,
-  fields: [],
   associations: [
-    {
-      id: uniqueId(),
+    association({
+      sourceModelId: Id.Post,
+      targetModelId: Id.Post,
       alias: 'parent',
       foreignKey: 'parent id',
-      sourceModelId: Id.Post,
-      targetModelId: Id.Post,
       type: belongsToType(),
-    },
-    {
-      id: uniqueId(),
-      alias: 'children',
-      foreignKey: null,
+    }),
+    association({
       sourceModelId: Id.Post,
       targetModelId: Id.Post,
+      alias: 'children',
       type: hasManyType(),
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      sourceModelId: Id.Post,
-      targetModelId: Id.PostCategory,
-      type: hasManyType(),
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({ sourceModelId: Id.Post, targetModelId: Id.PostCategory, type: hasManyType() }),
+    association({
       sourceModelId: Id.Post,
       targetModelId: Id.Category,
       type: manyToManyModelType(Id.PostCategory),
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      sourceModelId: Id.Post,
-      targetModelId: Id.PostTag,
-      type: hasManyType(),
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    }),
+    association({ sourceModelId: Id.Post, targetModelId: Id.PostTag, type: hasManyType() }),
+    association({
       sourceModelId: Id.Post,
       targetModelId: Id.Tag,
       type: manyToManyTableType('post_tag', 'tag_id'),
-    },
+    }),
   ],
-}
+})
 
-const postCategory: Model = {
+const postCategory: Model = model({
   id: Id.PostCategory,
   name: 'post category',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'post id',
       type: bigIntDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'category id',
       type: bigIntDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      sourceModelId: Id.PostCategory,
-      targetModelId: Id.Post,
-      type: belongsToType(),
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({ sourceModelId: Id.PostCategory, targetModelId: Id.Post, type: belongsToType() }),
+    association({
       sourceModelId: Id.PostCategory,
       targetModelId: Id.Category,
       type: belongsToType(),
-    },
+    }),
   ],
-}
+})
 
-const postTag: Model = {
+const postTag: Model = model({
   id: Id.PostTag,
   name: 'post tag',
   createdAt: time,
   updatedAt: time,
-  fields: [],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      sourceModelId: Id.PostTag,
-      targetModelId: Id.Post,
-      type: belongsToType(),
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      sourceModelId: Id.PostTag,
-      targetModelId: Id.Tag,
-      type: belongsToType(),
-    },
+    association({ sourceModelId: Id.PostTag, targetModelId: Id.Post, type: belongsToType() }),
+    association({ sourceModelId: Id.PostTag, targetModelId: Id.Tag, type: belongsToType() }),
   ],
-}
+})
 
-const tag: Model = {
+const tag: Model = model({
   id: Id.Tag,
   name: 'tag',
   createdAt: time,
   updatedAt: time,
-  fields: [],
   associations: [
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
-      sourceModelId: Id.Tag,
-      targetModelId: Id.PostTag,
-      type: hasManyType(),
-    },
-    {
-      id: uniqueId(),
-      alias: null,
-      foreignKey: null,
+    association({ sourceModelId: Id.Tag, targetModelId: Id.PostTag, type: hasManyType() }),
+    association({
       sourceModelId: Id.Tag,
       targetModelId: Id.Post,
       type: manyToManyModelType(Id.PostTag),
-    },
+    }),
   ],
-}
+})
 
-const associationsSchema: Schema = {
-  id: uniqueId(),
+const associationsSchema: Schema = schema({
+  name: 'associations',
   createdAt: time,
   updatedAt: time,
-  name: 'associations',
-  forkedFrom: null,
   models: [category, post, postCategory, postTag, tag],
-}
+})
 
 export default associationsSchema

--- a/src/frameworks/__fixtures__/schemas/dataTypes.ts
+++ b/src/frameworks/__fixtures__/schemas/dataTypes.ts
@@ -9,12 +9,15 @@ import {
   decimalDataType,
   doubleDataType,
   enumDataType,
+  field,
   floatDataType,
   integerDataType,
   jsonBDataType,
   jsonDataType,
+  model,
   Model,
   realDataType,
+  schema,
   Schema,
   smallIntDataType,
   stringDataType,
@@ -24,271 +27,142 @@ import {
   UuidType,
 } from '@src/core/schema'
 import { fromParts } from '@src/utils/dateTime'
-import { uniqueId } from '@src/utils/string'
 
 const time = fromParts(2021, 1, 1)
 
-const Id = {
-  DataType: uniqueId(),
-} as const
-
-const dataTypes: Model = {
-  id: Id.DataType,
+const dataTypes: Model = model({
   name: 'category',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'string',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'string with length',
       type: stringDataType({ length: 100 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'text',
       type: textDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'ci text',
       type: ciTextDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'integer',
       type: integerDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'integer unsigned',
       type: integerDataType({ unsigned: true }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'integer autoincrement',
       type: integerDataType({ autoincrement: true }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'big int',
       type: bigIntDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'small int',
       type: smallIntDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'float',
       type: floatDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'real',
       type: realDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'double',
       type: doubleDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'decimal',
       type: decimalDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'decimal precision',
       type: decimalDataType({ precision: { precision: 14, scale: null } }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'decimal precision and scale',
       type: decimalDataType({ precision: { precision: 14, scale: 2 } }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'date time',
       type: dateTimeDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'date time default now',
       type: dateTimeDataType({ defaultNow: true }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'date',
       type: dateDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'date default now',
       type: dateDataType({ defaultNow: true }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'time',
       type: timeDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'time default now',
       type: timeDataType({ defaultNow: true }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'boolean',
       type: booleanDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'enum',
       type: enumDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'array',
       type: arrayDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'json',
       type: jsonDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'json b',
       type: jsonBDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'blob',
       type: blobDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'uuid',
       type: uuidDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'uuid default v4',
       type: uuidDataType({ defaultVersion: UuidType.V4 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'uuid default v1',
       type: uuidDataType({ defaultVersion: UuidType.V1 }),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
-  associations: [],
-}
+})
 
-const dataTypesSchema: Schema = {
-  id: uniqueId(),
+const dataTypesSchema: Schema = schema({
   name: 'data types',
   createdAt: time,
   updatedAt: time,
-  forkedFrom: null,
   models: [dataTypes],
-}
+})
 
 export default dataTypesSchema

--- a/src/frameworks/__fixtures__/schemas/fields.ts
+++ b/src/frameworks/__fixtures__/schemas/fields.ts
@@ -1,62 +1,41 @@
-import { Model, Schema, stringDataType } from '@src/core/schema'
+import { Model, Schema, field, model, schema, stringDataType } from '@src/core/schema'
 import { fromParts } from '@src/utils/dateTime'
-import { uniqueId } from '@src/utils/string'
 
 const time = fromParts(2020, 7, 1)
 
-const Id = {
-  Field: uniqueId(),
-} as const
-
-const fields: Model = {
-  id: Id.Field,
+const fields: Model = model({
   name: 'category',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'field',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'pk field',
       type: stringDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'required field',
       type: stringDataType(),
-      primaryKey: false,
       required: true,
-      unique: false,
-    },
-    {
-      id: uniqueId(),
+    }),
+    field({
       name: 'optional field',
       type: stringDataType(),
-      primaryKey: false,
-      required: false,
       unique: true,
-    },
+    }),
   ],
   associations: [],
-}
+})
 
-const fieldsSchema: Schema = {
-  id: uniqueId(),
+const fieldsSchema: Schema = schema({
   name: 'fields',
   createdAt: time,
   updatedAt: time,
-  forkedFrom: null,
   models: [fields],
-}
+})
 
 export default fieldsSchema

--- a/src/frameworks/__fixtures__/schemas/pks.ts
+++ b/src/frameworks/__fixtures__/schemas/pks.ts
@@ -1,86 +1,58 @@
-import { integerDataType, Model, Schema } from '@src/core/schema'
+import { field, integerDataType, model, Model, schema, Schema } from '@src/core/schema'
 import { fromParts } from '@src/utils/dateTime'
-import { uniqueId } from '@src/utils/string'
 
 const time = fromParts(2020, 4, 1)
 
-const Id = {
-  Default: uniqueId(),
-  Id: uniqueId(),
-  Prefixed: uniqueId(),
-  NonStandard: uniqueId(),
-} as const
-
-const defaultPk: Model = {
-  id: Id.Default,
+const defaultPk: Model = model({
   name: 'default',
   createdAt: time,
   updatedAt: time,
-  fields: [],
-  associations: [],
-}
+})
 
-const id: Model = {
-  id: Id.Id,
+const id: Model = model({
   name: 'id',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'id',
       type: integerDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
-  associations: [],
-}
+})
 
-const prefixed: Model = {
-  id: Id.Prefixed,
+const prefixed: Model = model({
   name: 'prefixed',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'prefixed_id',
       type: integerDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
-  associations: [],
-}
+})
 
-const nonstandard: Model = {
-  id: Id.NonStandard,
+const nonstandard: Model = model({
   name: 'nonstandard',
   createdAt: time,
   updatedAt: time,
   fields: [
-    {
-      id: uniqueId(),
+    field({
       name: 'other_id',
       type: integerDataType(),
       primaryKey: true,
-      required: false,
-      unique: false,
-    },
+    }),
   ],
-  associations: [],
-}
+})
 
-const fieldsSchema: Schema = {
-  id: uniqueId(),
+const fieldsSchema: Schema = schema({
   name: 'fields',
   createdAt: time,
   updatedAt: time,
-  forkedFrom: null,
   models: [defaultPk, id, prefixed, nonstandard],
-}
+})
 
 export default fieldsSchema

--- a/src/frameworks/sequelize/utils/field.ts
+++ b/src/frameworks/sequelize/utils/field.ts
@@ -4,13 +4,14 @@ import {
   DataType,
   DataTypeType,
   dateTimeDataType,
+  field,
   Field,
   integerDataType,
   isDateTimeType,
   isIntegerType,
   Model,
 } from '@src/core/schema'
-import { camelCase, snakeCase, uniqueId } from '@src/utils/string'
+import { camelCase, snakeCase } from '@src/utils/string'
 import {
   displaySequelizeDataType,
   noSupportedDetails,
@@ -124,15 +125,14 @@ type IdFieldArgs = {
   dbOptions: DbOptions
 }
 export function idField({ model, dbOptions }: IdFieldArgs): SequelizeField {
-  return {
-    id: uniqueId(),
+  const fieldBase = field({
     name: getPkName({ model, dbOptions }),
     type: integerDataType({ autoincrement: true, unsigned: true }),
     primaryKey: true,
     required: true,
-    unique: false,
-    generated: true,
-  }
+  })
+
+  return { ...fieldBase, generated: true }
 }
 
 type GetPkNameArgs = {
@@ -149,23 +149,15 @@ type GetTimestampFieldsTemplateArgs = {
 }
 export function getTimestampFields({ dbOptions }: GetTimestampFieldsTemplateArgs): Field[] {
   if (!dbOptions.timestamps) return []
-  const createdAt: Field = {
-    id: uniqueId(),
+  const createdAt: Field = field({
     name: caseByDbCaseStyle('created at', dbOptions.caseStyle),
     type: dateTimeDataType(),
-    primaryKey: false,
-    required: false,
-    unique: false,
-  }
+  })
 
-  const updatedAt: Field = {
-    id: uniqueId(),
+  const updatedAt: Field = field({
     name: caseByDbCaseStyle('updated at', dbOptions.caseStyle),
     type: dateTimeDataType(),
-    primaryKey: false,
-    required: false,
-    unique: false,
-  }
+  })
 
   return [createdAt, updatedAt]
 }

--- a/src/frameworks/sequelize/utils/migrations.ts
+++ b/src/frameworks/sequelize/utils/migrations.ts
@@ -8,6 +8,9 @@ import {
   Association,
   AssociationTypeType,
   belongsToType,
+  association as buildAssociation,
+  field as buildField,
+  model as buildModel,
   Field,
   ManyToManyAssociation,
   Model,
@@ -199,14 +202,11 @@ function getFieldWithReference({
   const columnField = prefixPk({ field: pk, model: model, dbOptions })
   const column = caseByDbCaseStyle(columnField.name, dbOptions.caseStyle)
 
-  const field: Field = {
-    id: uniqueId(),
+  const field: Field = buildField({
     name: fk,
     type: resetType(pk.type),
     primaryKey,
-    required: false,
-    unique: false,
-  }
+  })
 
   return { ...field, reference: { table, column } }
 }
@@ -252,36 +252,30 @@ function getJoinTableModel(
     primaryKey: true,
   })
 
-  const sourceAssoc: Association = {
-    id: uniqueId(),
-    alias: null,
-    foreignKey: null,
+  const sourceAssoc: Association = buildAssociation({
     sourceModelId: id,
     targetModelId: source.id,
     type: belongsToType(),
-  }
+  })
 
   const targetFk = getForeignKey({ model: target, association, modelById, dbOptions })
 
   const targetFkField = getFieldWithReference({ model: target, fk: targetFk, dbOptions })
 
-  const targetAssoc: Association = {
-    id: uniqueId(),
-    alias: null,
-    foreignKey: null,
+  const targetAssoc: Association = buildAssociation({
     sourceModelId: id,
     targetModelId: target.id,
     type: belongsToType(),
-  }
+  })
 
-  return {
+  return buildModel({
     id,
     name: tableName,
     createdAt: source.createdAt,
     updatedAt: source.updatedAt,
     fields: [sourceFkField, targetFkField],
     associations: [sourceAssoc, targetAssoc],
-  }
+  })
 }
 
 type MigrationTimestamps = Map<number, Model>

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,2 +1,3 @@
 export type EmptyObject = Record<string, never>
 export type Override<A, B> = Omit<A, keyof B> & B
+export type AtLeast<T, K extends keyof T> = Partial<T> & Pick<T, K>


### PR DESCRIPTION
Ensures that `Schema`, `Model`, `Field` and `Association` types are always created using function constructors to make type easier to extend without relying on optional fields.